### PR TITLE
Delayed execution of `if` branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ antlr/*.tokens
 log/
 package-lock.json
 
+# Project files
+.idea
+*.iml
+.classpath
+.project
+target/
+.vscode

--- a/src/test/extensions.spec.js
+++ b/src/test/extensions.spec.js
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { jsonFormula } from '../json-formula';
+
+test('if executes correct branch', () => {
+  const expressionTrue = 'if(true(),true_fn(),false_fn())';
+  const expressionFalse = 'if(false(),true_fn(),false_fn())';
+  const customFunctions = {
+    true_fn: {
+      _func: () => true,
+      _signature: [],
+    },
+    false_fn: {
+      _func: () => false,
+      _signature: [],
+    },
+  };
+  const spyTrue = jest.spyOn(customFunctions.true_fn, '_func');
+  const spyFalse = jest.spyOn(customFunctions.false_fn, '_func');
+
+  const resultTrue = jsonFormula({}, {}, expressionTrue, customFunctions);
+  expect(resultTrue).toEqual(true);
+  expect(spyTrue).toHaveBeenCalled();
+  expect(spyFalse).not.toHaveBeenCalled();
+
+  jest.clearAllMocks();
+  const resultFalse = jsonFormula({}, {}, expressionFalse, customFunctions);
+  expect(spyTrue).not.toHaveBeenCalled();
+  expect(spyFalse).toHaveBeenCalled();
+  expect(resultFalse).toEqual(false);
+});


### PR DESCRIPTION
- add common project files to .gitignore
- Delayed execution of `if` branches.

## Description
The `if` function's branched will have code which can execute
side-effects. For example consider the expression:

  if(condition, dispatch_event("submit"), dispatch_event("error"))

In the current implementation both branches would be executed, which is
not something desired.

This change provides special handling for the `if` function since this
is the only function currently with this property. The arguements for
this function are resolved during function execution (similar to
exprefs). Additionally current data value is passed to the function call
as an extra argument in addition to the `unresolvedArgs` argument.
## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.