### PR TITLE
Add openformula based date time functions (#11)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,1 @@
+process.env.TZ = 'UTC';

--- a/jmespath.js/jmespath.js
+++ b/jmespath.js/jmespath.js
@@ -483,7 +483,7 @@ function JsonFormula() {
             start: this._current,
           });
           this._current += 1;
-        } else if ((stream[this._current] === '-' && !(prev === TOK_NUMBER || prev === TOK_RPAREN)) || isNum(stream[this._current], false)) {
+        } else if ((stream[this._current] === '-' && ![TOK_NUMBER, TOK_RPAREN, TOK_UNQUOTEDIDENTIFIER, TOK_QUOTEDIDENTIFIER].includes(prev)) || isNum(stream[this._current], false)) {
           token = this._consumeNumber(stream);
           tokens.push(token);
         } else if (stream[this._current] === '[') {

--- a/jmespath.js/openFormulaFunctions.js
+++ b/jmespath.js/openFormulaFunctions.js
@@ -342,5 +342,158 @@ export default function openFormulaFunctions(interpreter, valueOf, toString, toN
         { types: [dataTypes.TYPE_STRING] },
       ],
     },
+    date: {
+      _func: args => {
+        const year = toNumber(args[0]);
+        const month = toNumber(args[1]);
+        const day = toNumber(args[2]);
+        // javascript months starts from 0
+        const jsDate = Date.UTC(year, month - 1, day);
+        return Math.floor(jsDate / 86400000);
+      },
+      _signature: [
+        { types: [dataTypes.TYPE_NUMBER] },
+        { types: [dataTypes.TYPE_NUMBER] },
+        { types: [dataTypes.TYPE_NUMBER] },
+      ],
+    },
+    day: {
+      _func: args => {
+        const date = toNumber(args[0]);
+        const jsDate = new Date(date * 86400000);
+        return jsDate.getUTCDate();
+      },
+      _signature: [
+        { types: [dataTypes.TYPE_NUMBER] },
+      ],
+    },
+    month: {
+      _func: args => {
+        const date = toNumber(args[0]);
+        const jsDate = new Date(date * 86400000);
+        // javascript months start from 0
+        return jsDate.getUTCMonth() + 1;
+      },
+      _signature: [
+        { types: [dataTypes.TYPE_NUMBER] },
+      ],
+    },
+    year: {
+      _func: args => {
+        const date = toNumber(args[0]);
+        const jsDate = new Date(date * 86400000);
+        return jsDate.getUTCFullYear();
+      },
+      _signature: [
+        { types: [dataTypes.TYPE_NUMBER] },
+      ],
+    },
+    time: {
+      _func: args => {
+        const hours = toNumber(args[0]);
+        const minutes = toNumber(args[1]);
+        const seconds = toNumber(args[2]);
+        const time = (hours * 3600 + minutes * 60 + seconds) / 86400;
+        if (time < 0) {
+          return null;
+        }
+        return time - Math.floor(time);
+      },
+      _signature: [
+        { types: [dataTypes.TYPE_NUMBER] },
+        { types: [dataTypes.TYPE_NUMBER] },
+        { types: [dataTypes.TYPE_NUMBER] },
+      ],
+    },
+    hour: {
+      _func: args => {
+        const time = toNumber(args[0]);
+        if (time < 0) {
+          return null;
+        }
+        const hour = (time * 86400) / 3600;
+        return hour % 24;
+      },
+      _signature: [
+        { types: [dataTypes.TYPE_NUMBER] },
+      ],
+    },
+    minute: {
+      _func: args => {
+        const time = toNumber(args[0]);
+        if (time < 0) {
+          return null;
+        }
+        const minute = (time * 1440);
+        return minute % 60;
+      },
+      _signature: [
+        { types: [dataTypes.TYPE_NUMBER] },
+      ],
+    },
+    second: {
+      _func: args => {
+        const time = toNumber(args[0]);
+        if (time < 0) {
+          return null;
+        }
+        const seconds = (time * 86400);
+        return seconds % 60;
+      },
+      _signature: [
+        { types: [dataTypes.TYPE_NUMBER] },
+      ],
+    },
+    now: {
+      _func: () => {
+        const localDateTime = new Date();
+        const year = localDateTime.getFullYear();
+        const month = localDateTime.getMonth();
+        const date = localDateTime.getDate();
+        const hours = localDateTime.getHours();
+        const minutes = localDateTime.getMinutes();
+        const seconds = localDateTime.getSeconds();
+        const result = Date.UTC(year, month, date, hours, minutes, seconds) / 86400000;
+        return result;
+      },
+      _signature: [],
+    },
+    today: {
+      _func: () => {
+        const localDateTime = new Date();
+        const year = localDateTime.getFullYear();
+        const month = localDateTime.getMonth();
+        const date = localDateTime.getDate();
+        const result = Math.floor(Date.UTC(year, month, date) / 86400000);
+        return result;
+      },
+      _signature: [],
+    },
+    weekday: {
+      _func: args => {
+        const date = toNumber(args[0]);
+        const type = args.length > 1 ? toNumber(args[1]) : 1;
+        const jsDate = new Date(date * 86400000);
+        const day = jsDate.getUTCDay();
+        // day is in range [0-7) with 0 mapping to sunday
+        switch (type) {
+          case 1:
+            // range = [1, 7], sunday = 1
+            return day + 1;
+          case 2:
+            // range = [1, 7] sunday = 7
+            return ((day + 6) % 7) + 1;
+          case 3:
+            // range = [0, 6] sunday = 6
+            return (day + 6) % 7;
+          default:
+            return null;
+        }
+      },
+      _signature: [
+        { types: [dataTypes.TYPE_NUMBER] },
+        { types: [dataTypes.TYPE_NUMBER], optional: true },
+      ],
+    },
   };
 }

--- a/src/test/extensions.spec.js
+++ b/src/test/extensions.spec.js
@@ -74,6 +74,31 @@ test('creating second form should not affect first form', () => {
   const form2 = new Form(fieldData, data);
   const numFields2 = form2.$fields.length;
 
-  expect(form1.$fields.length).toEqual(numFields1);
+  expect(form1.$fields).toHaveLength(numFields1);
   expect(numFields1).toEqual(numFields2);
+});
+
+describe('current datetime tests', () => {
+  beforeEach(() => {
+    jest.useFakeTimers('modern');
+    // 2nd Jan 1970 12 PM
+    const datetime = 1.296e8;
+    jest.setSystemTime(datetime);
+  });
+
+  test('now returns the correct value', () => {
+    const expression = 'now()';
+    const result = jsonFormula({}, {}, expression, {}, stringToNumber);
+    expect(result).toEqual(1.5);
+  });
+
+  test('today returns the correct value', () => {
+    const expression = 'today()';
+    const result = jsonFormula({}, {}, expression, {}, stringToNumber);
+    expect(result).toEqual(1.0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
 });

--- a/src/test/sampleData.json
+++ b/src/test/sampleData.json
@@ -21,6 +21,20 @@
           "subtotal": 4.02
         }
       ]
+    },
+    "datetime": {
+      "epoch": {
+        "date": 1,
+        "month": 1,
+        "year": 1970,
+        "value": 0
+      },
+      "noon": {
+        "hour": 12,
+        "minute": 0,
+        "second": 0,
+        "value": 0.5
+      }
     }
   }
 }

--- a/src/test/tests.json
+++ b/src/test/tests.json
@@ -263,6 +263,14 @@
     }
   ],
   [
+    "subtract expressions",
+    {
+      "data": "samples.\"purchase-order\"",
+      "expression": "items[0].quantity - 2",
+      "expected": 0
+    }
+  ],
+  [
     "substitute(1)",
     {
       "data": "`{\"a\": \"abbabba\", \"b\": \"abba\", \"c\": \"a\"}`",

--- a/src/test/tests.json
+++ b/src/test/tests.json
@@ -1439,5 +1439,365 @@
       "expression": "codePoint(address.street)",
       "expected": 49
     }
+  ],
+  [
+    "date(1970,1,1)",
+    {
+      "data": "`null`",
+      "expression": "date(1970,1,1)",
+      "expected": 0
+    }
+  ],
+  [
+    "date('1970',1,1)",
+    {
+      "data": "`null`",
+      "expression": "date('1970',1,1)",
+      "expected": 0
+    }
+  ],
+  [
+    "date(1969,12,31)",
+    {
+      "data": "`null`",
+      "expression": "date(1969,12,31)",
+      "expected": -1
+    }
+  ],
+  [
+    "date(2020,2,29)",
+    {
+      "data": "`null`",
+      "expression": "date(2020,2,29)",
+      "expected": 18321
+    }
+  ],
+  [
+    "date(2020,3,1)",
+    {
+      "data": "`null`",
+      "expression": "date(2020,3,1)",
+      "expected": 18322
+    }
+  ],
+  [
+    "date(date(epoch.year, epoch.month, epoch.date))",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "date(epoch.year, epoch.month, epoch.date)",
+      "expected": 0
+    }
+  ],
+  [
+    "date(1970,1,1) | day(@)",
+    {
+      "data": "`null`",
+      "expression": "date(1970,1,1) | day(@)",
+      "expected": 1
+    }
+  ],
+  [
+    "day(0)",
+    {
+      "data": "`null`",
+      "expression": "day(0)",
+      "expected": 1
+    }
+  ],
+  [
+    "day(1.5)",
+    {
+      "data": "`null`",
+      "expression": "day(1.5)",
+      "expected": 2
+    }
+  ],
+  [
+    "day(epoch.value)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "day(epoch.value)",
+      "expected": 1
+    }
+  ],
+  [
+    "date(1970,1,1) | month(@)",
+    {
+      "data": "`null`",
+      "expression": "date(1970,1,1) | month(@)",
+      "expected": 1
+    }
+  ],
+  [
+    "date(2020,2,29) | month(@)",
+    {
+      "data": "`null`",
+      "expression": "date(2020,2,29) | month(@)",
+      "expected": 2
+    }
+  ],
+  [
+    "date(2020,2,30) | month(@)",
+    {
+      "data": "`null`",
+      "expression": "date(2020,2,30) | month(@)",
+      "expected": 3
+    }
+  ],
+  [
+    "month(epoch.value)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "month(epoch.value)",
+      "expected": 1
+    }
+  ],
+  [
+    "date(1970,1,1) | year(@)",
+    {
+      "data": "`null`",
+      "expression": "date(1970,1,1) | year(@)",
+      "expected": 1970
+    }
+  ],
+  [
+    "date(1969,1,1) | year(@)",
+    {
+      "data": "`null`",
+      "expression": "date(1969,1,1) | year(@)",
+      "expected": 1969
+    }
+  ],
+  [
+    "date(1969,1,1) | year(@)",
+    {
+      "data": "`null`",
+      "expression": "date(1969,1,1) | year(@)",
+      "expected": 1969
+    }
+  ],
+  [
+    "year(epoch.value)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "year(epoch.value)",
+      "expected": 1970
+    }
+  ],
+  [
+    "time(0, 0, 0)",
+    {
+      "data": "`null`",
+      "expression": "time(0, 0, 0)",
+      "expected": 0
+    }
+  ],
+  [
+    "time(6, 0, 0)",
+    {
+      "data": "`null`",
+      "expression": "time(6, 0, 0)",
+      "expected": 0.25
+    }
+  ],
+  [
+    "time('6', '0', '0')",
+    {
+      "data": "`null`",
+      "expression": "time('6', '0', '0')",
+      "expected": 0.25
+    }
+  ],
+  [
+    "time(noon.hour, noon.minute, noon.second)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "time(noon.hour, noon.minute, noon.second)",
+      "expected": 0.5
+    }
+  ],
+  [
+    "hour(0.25)",
+    {
+      "data": "`null`",
+      "expression": "hour(0.25)",
+      "expected": 6
+    }
+  ],
+  [
+    "hour(-0.1)",
+    {
+      "data": "`null`",
+      "expression": "hour(-0.1)",
+      "expected": null
+    }
+  ],
+  [
+    "hour(3.33333333333)",
+    {
+      "data": "`null`",
+      "expression": "hour(3.33333333333)",
+      "expected": 8
+    }
+  ],
+  [
+    "hour(noon.value)", {
+      "data": "samples.\"datetime\"",
+      "expression": "hour(noon.value)",
+      "expected": 12
+    }
+  ],
+  [
+    "minute(0.0375)",
+    {
+      "data": "`null`",
+      "expression": "minute(0.0375)",
+      "expected": 54
+    }
+  ],
+  [
+    "minute(-0.1)",
+    {
+      "data": "`null`",
+      "expression": "minute(-0.1)",
+      "expected": null
+    }
+  ],
+  [
+    "minute(3.0375)",
+    {
+      "data": "`null`",
+      "expression": "minute(3.0375)",
+      "expected": 54
+    }
+  ],
+  [
+    "minute(noon.value)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "minute(noon.value)",
+      "expected": 0
+    }
+  ],
+  [
+    "second(0.000625)",
+    {
+      "data": "`null`",
+      "expression": "second(0.000625)",
+      "expected": 54
+    }
+  ],
+  [
+    "second(-0.1)",
+    {
+      "data": "`null`",
+      "expression": "second(-0.1)",
+      "expected": null
+    }
+  ],
+  [
+    "second(3.000625)",
+    {
+      "data": "`null`",
+      "expression": "second(3.000625)",
+      "expected": 54
+    }
+  ],
+  [
+    "second(noon.value)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "second(noon.value)",
+      "expected": 0
+    }
+  ],
+  [
+    "weekday(date(1970, 1, 1))",
+    {
+      "data": "`null`",
+      "expression": "weekday(date(1970, 1, 1))",
+      "expected": 5
+    }
+  ],
+  [
+    "weekday(epoch.value)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "weekday(epoch.value)",
+      "expected": 5
+    }
+  ],
+  [
+    "weekday(epoch.value + 2)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "weekday(epoch.value + 2)",
+      "expected": 7
+    }
+  ],
+  [
+    "weekday((epoch.value - 5))",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "weekday(epoch.value - 5)",
+      "expected": 7
+    }
+  ],
+  [
+    "weekday(epoch.value + 3)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "weekday(epoch.value + 3)",
+      "expected": 1
+    }
+  ],
+  [
+    "weekday(epoch.value + 3, 1)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "weekday(epoch.value + 3, 1)",
+      "expected": 1
+    }
+  ],
+  [
+    "weekday(epoch.value + 3, 2)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "weekday(epoch.value + 3, 2)",
+      "expected": 7
+    }
+  ],
+  [
+    "weekday(epoch.value + 4, 2)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "weekday(epoch.value + 4, 2)",
+      "expected": 1
+    }
+  ],
+  [
+    "weekday(epoch.value + 3, 3)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "weekday(epoch.value + 3, 3)",
+      "expected": 6
+    }
+  ],
+  [
+    "weekday(epoch.value, 4)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "weekday(epoch.value, 4)",
+      "expected": null
+    }
+  ],
+  [
+    "weekday(epoch.value, -1)",
+    {
+      "data": "samples.\"datetime\"",
+      "expression": "weekday(epoch.value, -1)",
+      "expected": null
+    }
   ]
 ]
+


### PR DESCRIPTION
## Description
Changes:
- Add open-formula based date-time functions
  - Non-open-formula functions like `parseDate`, `parseDateTime`, `formatDate`, etc. are not part of this change.
- Fix a minor bug in lexer which prevents subtraction on expressions and numbers. 
  - Example: `toString(a - 2)` results in `Error: ArgumentError: toString() takes 1 argument but received 3`

## Related Issue
#11 
## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.