### PR TITLE
:refactor Allow formulas to be re-used

### DIFF
--- a/jmespath.js/jmespath.js
+++ b/jmespath.js/jmespath.js
@@ -1600,8 +1600,7 @@ function JsonFormula() {
     return lexer.tokenize(stream);
   }
 
-  function search(data, globals, expression, customFunctions, stringToNumberFn) {
-    const parser = new Parser();
+  function search(node, data, globals, customFunctions, stringToNumberFn) {
     // This needs to be improved.  Both the interpreter and runtime depend on
     // each other.  The runtime needs the interpreter to support exprefs.
     // There's likely a clean way to avoid the cyclic dependency.
@@ -1614,7 +1613,6 @@ function JsonFormula() {
       const n = +str;
       return Number.isNaN(n) ? 0 : n;
     });
-    const node = parser.parse(expression);
     return interpreter.search(node, data);
   }
   this.tokenize = tokenize;

--- a/src/json-formula.js
+++ b/src/json-formula.js
@@ -11,8 +11,24 @@ governing permissions and limitations under the License.
 */
 import jmespath from '../jmespath.js/jmespath';
 
+export class Formula {
+  constructor(expression, customFunctions = {}, stringToNumber) {
+    this.expression = expression;
+    this.customFunctions = customFunctions;
+    this.stringToNumber = stringToNumber;
+    this.node = jmespath.compile(expression);
+  }
+
+  search(json, globals) {
+    const result = jmespath.search(this.node, json, globals, { ...this.customFunctions },
+      this.stringToNumber);
+    return result;
+  }
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export function jsonFormula(json, globals, expression, customFunctions = {}, stringToNumber) {
-  const x = jmespath.search(json, globals, expression, { ...customFunctions }, stringToNumber);
-  return x;
+  const formula = new Formula(expression, customFunctions, stringToNumber);
+  const result = formula.search(json, globals, { ...customFunctions }, stringToNumber);
+  return result;
 }


### PR DESCRIPTION
## Description
Changes:
 - Expose a `Formula` class in json-formula. The expression is
   pre-compiled during object construction.

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.