### PR TITLE
Enable access to interpreter in functions

### DIFF
--- a/src/jmespath/TreeInterpreter.js
+++ b/src/jmespath/TreeInterpreter.js
@@ -313,12 +313,12 @@ export default class TreeInterpreter {
       // Special case for if()
       // we need to make sure the results are called only after the condition is evaluated
       // Otherwise we end up with both results invoked -- which could include side effects
-        if (node.name === 'if') return this.runtime.callFunction(node.name, node.children, value);
+        if (node.name === 'if') return this.runtime.callFunction(node.name, node.children, value, this);
         const resolvedArgs = [];
         for (let i = 0; i < node.children.length; i += 1) {
           resolvedArgs.push(this.visit(node.children[i], value));
         }
-        return this.runtime.callFunction(node.name, resolvedArgs);
+        return this.runtime.callFunction(node.name, resolvedArgs, value, this);
       },
 
       ExpressionReference: node => {

--- a/src/jmespath/jmespath.js
+++ b/src/jmespath/jmespath.js
@@ -62,7 +62,7 @@ function JsonFormula() {
           getValueOf,
           toString,
         ),
-        ...openFormulaFunctions(this._interpreter, getValueOf, toString, toNumber),
+        ...openFormulaFunctions(getValueOf, toString, toNumber),
         ...customFunctions,
       };
     }
@@ -106,11 +106,11 @@ function JsonFormula() {
       }
     }
 
-    callFunction(name, resolvedArgs, data) {
+    callFunction(name, resolvedArgs, data, interpreter) {
       const functionEntry = this.functionTable[name];
       if (functionEntry === undefined) throw new Error(`Unknown function: ${name}()`);
       this._validateArgs(name, resolvedArgs, functionEntry._signature);
-      return functionEntry._func.call(this, resolvedArgs, data);
+      return functionEntry._func.call(this, resolvedArgs, data, interpreter);
     }
   }
 

--- a/src/jmespath/openFormulaFunctions.js
+++ b/src/jmespath/openFormulaFunctions.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 import dataTypes from './dataTypes';
 
-export default function openFormulaFunctions(interpreter, valueOf, toString, toNumber) {
+export default function openFormulaFunctions(valueOf, toString, toNumber) {
   return {
     and: {
       _func: resolveArgs => !!valueOf(resolveArgs[0]) && !!valueOf(resolveArgs[1]),
@@ -39,7 +39,7 @@ export default function openFormulaFunctions(interpreter, valueOf, toString, toN
     },
 
     if: {
-      _func: (unresolvedArgs, data) => {
+      _func: (unresolvedArgs, data, interpreter) => {
         const conditionNode = unresolvedArgs[0];
         const leftBranchNode = unresolvedArgs[1];
         const rightBranchNode = unresolvedArgs[2];

--- a/src/test/extensions.spec.js
+++ b/src/test/extensions.spec.js
@@ -156,4 +156,21 @@ describe('expressions with globals', () => {
     const result2 = jsonFormula(json, globals, 'form', {}, stringToNumber);
     expect(result2).toEqual(null);
   });
+
+  test('access globals in custom functions', () => {
+    const globals = {
+      element: 'value',
+    };
+    const customFunctions = {
+      customFunc: {
+        _func: (args, searchData, interpreter) => {
+          return interpreter.globals.element;
+        },
+        _signature: [],
+      },
+    };
+    const expression = 'customFunc()';
+    const result = jsonFormula({}, globals, expression, customFunctions, stringToNumber);
+    expect(result).toEqual(globals.element);
+  });
 });


### PR DESCRIPTION
## Description
Pass the interpreter as an optional parameter to the functions
This allows functions access to:
 - interpreter
 - globals
 - debug flag

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.