### PR TITLE
Expand grammar to allow bracketed expressions

### DIFF
--- a/antlr/JSONFormula.g4
+++ b/antlr/JSONFormula.g4
@@ -16,7 +16,7 @@ formula : expression EOF ;
 
 expression
   : expression '.' chainedExpression # chainExpression
-  | expression bracketSpecifier # bracketedExpression
+  | expression chainedBracketSpecifier # bracketedExpression
   | bracketSpecifier # bracketExpression
   | expression ('*' | '/' | '&') expression	# multDivExpression
 	| expression ('+' | '-') expression	# addSubtractExpression
@@ -62,6 +62,11 @@ bracketSpecifier
   | '[' slice ']' # bracketSlice
   | '[' ']' # bracketFlatten
   | '[?' expression ']' # select
+  ;
+
+chainedBracketSpecifier
+  : bracketSpecifier # chainedBracket
+  | '[' expression ']' # chainedBracketIndex
   ;
 
 slice : start=SIGNED_INT? ':' stop=SIGNED_INT? (':' step=SIGNED_INT?)? ;

--- a/src/jmespath/TreeInterpreter.js
+++ b/src/jmespath/TreeInterpreter.js
@@ -123,7 +123,7 @@ export default class TreeInterpreter {
 
       Index: (node, value) => {
         if (!isArray(value)) return null;
-        let index = node.value;
+        let index = this.toNumber(this.visit(node.value, value));
         if (index < 0) {
           index = value.length + index;
         }
@@ -137,7 +137,9 @@ export default class TreeInterpreter {
 
       Slice: (node, value) => {
         if (!isArray(value)) return null;
-        const sliceParams = node.children.slice(0);
+        const sliceParams = node.children.slice(0).map(
+          param => (param != null ? this.toNumber(this.visit(param, value)) : null),
+        );
         const computed = this.computeSliceParams(value.length, sliceParams);
         const [start, stop, step] = computed;
         const result = [];

--- a/src/test/extensions.spec.js
+++ b/src/test/extensions.spec.js
@@ -172,3 +172,41 @@ describe('expressions with globals', () => {
     expect(result).toEqual(globals.element);
   });
 });
+
+test('expressions in brackets', () => {
+  const sample = {
+    array: [0, 1, 2, 3, 4],
+    zero: 0,
+    one: 1,
+    two: 2,
+    three: 3,
+    ten: 10,
+  };
+  const testcases = [
+    ['array[$form.zero]', 0],
+    ['array[$form.one + $form.two]', 3],
+    ['array[$form.zero:]', [0, 1, 2, 3, 4]],
+    ['array[0:$form.two]', [0, 1]],
+    ['array[$form.zero:length(@)-1:$form.one]', [0, 1, 2, 3]],
+    ['array | [$form.ten]', [10]],
+    ['array | [::$form.two]', [0, 2, 4]],
+    ['array | [0::$form.two]', [0, 2, 4]],
+    ['array | [$form.zero::$form.two]', [0, 2, 4]],
+  ];
+  const globals = {
+    $form: sample,
+  };
+  testcases.forEach(([expression, expected]) => {
+    const result = jsonFormula(sample, globals, expression, {}, stringToNumber);
+    expect(result).toEqual(expected);
+  });
+
+  const failures = [
+    'array[3 3]',
+    'array[$form.zero:$form.ten:$form.one:$form.one]',
+    'array[$form.zero, $form.one]',
+  ];
+  failures.forEach(expression => {
+    expect(() => jsonFormula(sample, globals, expression, {}, stringToNumber)).toThrow();
+  });
+});

--- a/src/test/jmespath/slice.json
+++ b/src/test/jmespath/slice.json
@@ -128,7 +128,8 @@
     },
     {
       "expression": "foo[2:a:3]",
-      "error": "syntax"
+      "result": [2, 5, 8],
+      "was": "syntax"
     }
   ]
 }, {

--- a/src/test/jmespath/syntax.json
+++ b/src/test/jmespath/syntax.json
@@ -242,7 +242,8 @@
       {
         "comment": "slice expected colon or rbracket",
         "expression": "[:@]",
-        "error": "syntax"
+        "result": null,
+        "was": "syntax"
       },
       {
         "comment": "slice has too many colons",
@@ -253,7 +254,8 @@
       {
         "comment": "slice expected number",
         "expression": "[:@:]",
-        "error": "syntax"
+        "result": null,
+        "was": "syntax"
       },
       {
         "comment": "slice expected number of colon",
@@ -307,7 +309,8 @@
       {
         "comment": "Multi-select of a list using an identifier index",
         "expression": "foo[abc]",
-        "error": "syntax"
+        "was": "syntax",
+        "result": null
       },
       {
         "comment": "Multi-select of a list using identifier indices",
@@ -568,7 +571,8 @@
       },
       {
         "expression": "foo[bar==baz]",
-        "error": "syntax"
+        "result": null,
+        "was": "syntax"
       },
       {
         "comment": "Quoted identifier in filter expression no spaces",

--- a/src/test/tests.json
+++ b/src/test/tests.json
@@ -1890,6 +1890,14 @@
       "expression": "address.valueOf",
       "expected": null
     }
+  ],
+  [
+    "index using expressions",
+    {
+      "data": "samples.\"purchase-order\"",
+      "expression": "items[length(@)-1].desc",
+      "expected": "pencils"
+    }
   ]
 ]
 


### PR DESCRIPTION
Fixes #16

This change enables the grammar to allow expressions within brackets.
After this, the following two cases will be treated seperately to
avoid breaking existing compatability with JMESPath.
 - chained brackets (example: `array[expression]`)
 - unchained brackets (example: `array | [expression]`)

Expressions will be allowed within chained brackets to index  both index
and slice expressions. Like before, multi-selects are not allowed within
chained brackets.

Expressions will be allowed within unchained brackets. However, for
compatibility reasons only numbers within brackets would map to index
expressions. For example the following will hold:
 - `array | [1]` : index the first element of array
 - `array | [one]` : create a multiselect list with a single element
                     `one`

slice expressions would support expressions inside brackets for both the
cases.

Other changes:
 - Fix an earlier parser behavior where `array[: 12 13 ]` was a valid
   syntax and was equivalent to `array[:13]`

## Related Issue
#16

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.