### PR TITLE
don't use regex lookbehind, as it's not yet supported on Safari

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
       {
-        "type": "pwa-chrome",
+        "type": "chrome",
         "name": "http://localhost:8085",
         "request": "launch",
         "url": "http://localhost:8085"
@@ -46,7 +46,6 @@
         },
         "console": "integratedTerminal",
         "internalConsoleOptions": "neverOpen",
-        "disableOptimisticBPs": true,
         "windows": {
           "program": "${workspaceFolder}/node_modules/jest/bin/jest",
         }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ To compare with the jmespath equivalent:
 
 ## Running Tests
 
-To run the tests, [re]generation of JavaScript code is a must using the command `source generate.sh`
+To run the tests, [re]generation of JavaScript code is a must using the command `source generate.sh`.
+The tests require an 18.x version of node.
 
 ```
 npm run test

--- a/src/jmespath/openFormulaFunctions.js
+++ b/src/jmespath/openFormulaFunctions.js
@@ -934,12 +934,10 @@ export default function openFormulaFunctions(valueOf, toString, toNumber, debug 
         // escape all characters that would otherwise create a regular expression
         const reString = findText.replace(/([[.\\^$()+{])/g, '\\$1')
           // add the single character wildcard
-          .replace(/(?<!~)\?/g, '.')
+          .replace(/~?\?/g, match => match === '~?' ? '\\?' : '.')
           // add the multi-character wildcard
-          .replace(/(?<!~)\*/g, '.*?')
+          .replace(/~?\*/g, match => match === '~*' ? '\\*' : '.*?')
           // get rid of the escape characters
-          .replace(/~\*/g, '\\*')
-          .replace(/~\?/g, '\\?')
           .replace(/~~/g, '~');
         const re = new RegExp(reString);
         const result = withinText.substring(startPos).match(re);


### PR DESCRIPTION
## Description
Code for the new search() function used regex lookbehind functionality which is not yet supported in all browsers.