### PR TITLE
Consistent treatment of indexing expressions on the current context

### DIFF
--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -66,6 +66,7 @@ const {
   TOK_LBRACKET,
   TOK_LPAREN,
   TOK_JSON,
+  TOK_STRING,
 } = tokenDefinitions;
 
 // The "&", "[", "<", ">" tokens
@@ -177,7 +178,7 @@ export default class Lexer {
         start = this._current;
         identifier = this._consumeRawStringLiteral(stream);
         tokens.push({
-          type: TOK_JSON,
+          type: TOK_STRING,
           value: identifier,
           start,
         });

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -69,6 +69,7 @@ const {
   TOK_LBRACE,
   TOK_LBRACKET,
   TOK_LPAREN,
+  TOK_STRING
 } = tokenDefinitions;
 
 const bindingPower = {
@@ -201,6 +202,8 @@ export default class Parser {
     let node;
     let args;
     switch (token.type) {
+      case TOK_STRING:
+        return { type: 'String', value: token.value };
       case TOK_JSON:
         return { type: 'Literal', value: token.value };
       case TOK_NUMBER:
@@ -425,7 +428,7 @@ export default class Parser {
       const right = this._parseSliceExpression();
       return this._projectIfSlice({ type: 'Identity' }, right);
     }
-    if (firstToken === TOK_NUMBER || firstToken === TOK_UNARY_MINUS) {
+    if (firstToken === TOK_STRING || firstToken === TOK_NUMBER || firstToken === TOK_UNARY_MINUS) {
       this._match(TOK_RBRACKET);
       return {
         type: 'Index',

--- a/src/TreeInterpreter.js
+++ b/src/TreeInterpreter.js
@@ -118,7 +118,12 @@ export default class TreeInterpreter {
           return result;
         }
         if (isObject(value)) {
-          const key = this.toString(this.visit(node.value, value));
+          const key = this.visit(node.value, value);
+          if (getTypeName(key) !== 'string') {
+            this.debug.push(`Invalid key (${key}) for indexing an object`);
+            if (getTypeName(key) === 'number') this.debug.push('Were you trying to define a one-element array? (use a JSON literal)');
+            return null;
+          }
           const result = value[key];
           if (result === undefined) {
             this.debug.push(`Key ${key} does not exist`);
@@ -333,6 +338,8 @@ export default class TreeInterpreter {
         }
         return minus;
       },
+
+      String: node => node.value,
 
       Literal: node => node.value,
 

--- a/src/tokenDefinitions.js
+++ b/src/tokenDefinitions.js
@@ -63,4 +63,5 @@ export default {
   TOK_LBRACKET: 'Lbracket',
   TOK_LPAREN: 'Lparen',
   TOK_JSON: 'Literal',
+  TOK_STRING: 'String',
 };

--- a/test/tests.json
+++ b/test/tests.json
@@ -3206,5 +3206,21 @@
       "expression": "2----1",
       "expected": 3
     }
+  ],
+  [
+    "zero key",
+    {
+      "data": "`{\"0\": \"zero\",\"1\": \"one\"}`",
+      "expression": "@[0] ~ @[\"1\"]",
+      "expected": ["one"]
+    }
+  ],
+  [
+    "0 key",
+    {
+      "data": "`{\"0\": \"zero\",\"1\": \"one\"}`",
+      "expression": "[\"0\"]",
+      "expected": "zero"
+    }
   ]
 ]


### PR DESCRIPTION
- The parser creates TOK_JSON for both a JSON literal and a string literal. We need to add a new TOK_STRING.
- A string based indexing expression needs to index the current context. Currently an expression such as ["a"] will always be treated as an array expression
- We need better debug when an ambiguous index expression/array expression are encountered
