### PR TITLE
More consistent null handling

### DIFF
--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -107,7 +107,7 @@ Coercion is not always possible, and if so, an `invalid-type` <<Errors,error>> s
 | boolean | number | true -> 1 false -> 0
 | array | number | Not supported
 | object | number | Not supported
-| null | number | null
+| null | number | 0
 | number | array | create a single-element array with the number
 | string | array | create a single-element array with the string
 | boolean | array | create a single-element array with the boolean
@@ -1281,7 +1281,7 @@ be used to convert all elements to numbers:
 
 [source%unbreakable]
 ----
-    eval([].toNumber(@), ["1", "2", "3", "notanumber", null, true]) -> [1,2,3,0,null,1]
+    eval([].toNumber(@), ["1", "2", "3", "notanumber", null, true]) -> [1,2,3,null,0,1]
 ----
 
 === Function Reference

--- a/src/functions.js
+++ b/src/functions.js
@@ -469,14 +469,15 @@ export default function functions(
     },
 
     /**
-     * Returns an array of `[key, value]` pairs from an object.
-     * The `fromEntries()` function may be used to convert the array back to an object.
-     * @param {object} obj source object
+     * Returns an array of `[key, value]` pairs from an object or array.
+     * The `fromEntries()` function may be used to convert an array to an object.
+     * @param {object|array} obj source object or array
      * @returns {any[]} an array of arrays where each child array has two elements
      * representing the key and value of a pair
      * @function entries
      * @example
      * entries({a: 1, b: 2}) // returns [["a", 1], ["b", 2]]
+     * entries([4,5]) // returns [["0", 4],["1", 5]]
      */
     entries: {
       _func: args => {
@@ -486,11 +487,8 @@ export default function functions(
       _signature: [
         {
           types: [
-            dataTypes.TYPE_NUMBER,
-            dataTypes.TYPE_STRING,
             dataTypes.TYPE_ARRAY,
             dataTypes.TYPE_OBJECT,
-            dataTypes.TYPE_BOOLEAN,
           ],
         },
       ],
@@ -609,7 +607,8 @@ export default function functions(
     fromCodePoint: {
       _func: args => {
         const code = args[0];
-        return !Number.isInteger(code) ? null : String.fromCodePoint(code);
+        if (!Number.isInteger(code)) throw typeError(`fromCodePoint() requires an integer parameter.  Received: "${code}"`);
+        return String.fromCodePoint(code);
       },
       _signature: [
         { types: [dataTypes.TYPE_NUMBER] },
@@ -772,7 +771,7 @@ export default function functions(
     /**
      * Calculates the length of the input argument based on types:
      *
-     * * string: returns the number of code points
+     * * string: returns the number of unicode code points
      * * array: returns the number of array elements
      * * object: returns the number of key-value pairs
      * @param {string | array | object} subject subject whose length to calculate
@@ -1906,14 +1905,14 @@ export default function functions(
      *
      * @param {string|number|boolean|null} arg to convert to number
      * @param {integer} [base=10] The base to use.  One of: 2, 8, 10, 16. Defaults to 10.
-     * @return {number}
+     * @return {number} The resulting number.  If conversion to number fails, return null.
      * @function toNumber
      * @example
      * toNumber(1) // returns 1
      * toNumber("10") // returns 10
      * toNumber({a: 1}) // fails
      * toNumber(true()) // returns 1
-     * toNumber("10f") // returns 0
+     * toNumber("10f") // returns null
      * toNumber("FF", 16) // returns 255
      */
     toNumber: {

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -49,7 +49,7 @@ const {
 function getToNumber(stringToNumber, debug = []) {
   return value => {
     const n = getValueOf(value); // in case it's an object that implements valueOf()
-    if (n === null) return null;
+    if (n === null) return 0;
     if (n instanceof Array) {
       throw typeError('Failed to convert array to number');
     }

--- a/src/stringToNumber.js
+++ b/src/stringToNumber.js
@@ -14,7 +14,7 @@ export default function stringToNumber(n, debug) {
   const ret = +n;
   if (Number.isNaN(ret)) {
     if (debug) debug.push(`Failed to convert "${n}" to number`);
-    return 0;
+    return null;
   }
   return ret;
 }

--- a/test/docSamples.json
+++ b/test/docSamples.json
@@ -35,7 +35,13 @@
       ]
     }
   ],
-
+  [
+    "entries([4,5])",
+    {
+      "expression": "entries([4,5])",
+      "expected": [["0", 4],["1", 5]]
+    }
+  ],
   [
     "fromEntries([[\"a\", 1], [\"b\", 2]])",
     {
@@ -354,7 +360,7 @@
     "toNumber(\"10f\")",
     {
       "expression": "toNumber(\"10f\")",
-      "expected": 0
+      "expected": null
     }
   ],
 

--- a/test/jmespath/functions.json
+++ b/test/jmespath/functions.json
@@ -644,8 +644,7 @@
       },
       {
         "expression": "toNumber(\"notanumber\")",
-        "result": 0,
-        "was": null
+        "result": null
       },
       {
         "expression": "toNumber(`false`)",
@@ -665,7 +664,11 @@
       },
       {
         "expression": "toNumber(`null`)",
-        "result": null
+        "result": 0
+      },
+      {
+        "expression": "toNumber(toNumber(\"a\"))",
+        "result": 0
       },
       {
         "expression": "toNumber(`[0]`)",
@@ -761,7 +764,7 @@
       {
         "description": "function projection on single arg function",
         "expression": "array[].toNumber(@)",
-        "result": [-1, 3, 4, 5, 0, 100],
+        "result": [-1, 3, 4, 5, null, 100],
         "was": [-1, 3, 4, 5, 100]
       }
     ]

--- a/test/jmespath/slice.json
+++ b/test/jmespath/slice.json
@@ -128,7 +128,7 @@
     },
     {
       "expression": "foo[2:a:3]",
-      "result": [2, 5, 8],
+      "result": [],
       "was": "SyntaxError"
     }
   ]

--- a/test/specSamples.json
+++ b/test/specSamples.json
@@ -114,7 +114,7 @@
     ["1e2", {}, 100],
     ["foo[?a < b]", {"foo": [{"a": "char", "b": "bar"}, {"a": 2, "b": 1}, {"a": 1, "b": 2}, {"a": false, "b": "1"}, {"a": 10, "b": "12"}]}, [ {"a": 1, "b": 2}, {"a": false, "b": "1"}, {"a": 10, "b": "12"} ]],
     ["foo[?a < b]", {"foo": [{"a": "char", "b": "bar"}, {"a": 2, "b": 1}, {"a": 1, "b": 2}, {"a": false, "b": "1"}, {"a": 10, "b": "12"}]}, [ {"a": 1, "b": 2}, {"a": false, "b": "1"}, {"a": 10, "b": "12"} ]],
-    ["[].toNumber(@)", ["1", "2", "3", "notanumber", null, true], [1,2,3,0,null,1]],
+    ["[].toNumber(@)", ["1", "2", "3", "notanumber", null, true], [1,2,3,null,0,1]],
     ["foo", {"foo": -1, "bar": "2"}, -1],
     ["bar", {"foo": -1, "bar": "2"}, "2"],
     ["foo[*].bar[0]", {"foo": [{"bar": ["first1", "second1"]}, {"bar": ["first2", "second2"]}]}, ["first1", "first2"]],

--- a/test/tests.json
+++ b/test/tests.json
@@ -1859,7 +1859,7 @@
     {
       "data": "`null`",
       "expression": "fromCodePoint(9.123)",
-      "expected": null
+      "error": "TypeError"
     }
   ],
   [
@@ -1867,7 +1867,7 @@
     {
       "data": "samples.'purchase-order'",
       "expression": "fromCodePoint(missing)",
-      "expected": null
+      "expected": "\u0000"
     }
   ],
   [
@@ -2430,7 +2430,7 @@
     {
       "data": "`null`",
       "expression": "entries(`null`)",
-      "error": "TypeError"
+      "expected": []
     }
   ],
   [
@@ -2438,7 +2438,7 @@
     {
       "data": "samples.'purchase-order'",
       "expression": "entries(address.country)",
-      "expected": [["0", "U"], ["1", "S"], ["2", "A"]]
+      "expected": [["0", "USA"]]
     }
   ],
   [


### PR DESCRIPTION
- toNumber() failures for strings will return null instead of zero
- When coercing null to number, coerce it as a zero

https://github.com/adobe/json-formula/issues/97