### PR TITLE
make min/max functions consistent with comparison operators and sorting

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -930,17 +930,9 @@ export default function functions(
         if (array.length === 0 || first === undefined) return null;
         // use the first value to determine the comparison type
         const isNumber = getType(first, true) === TYPE_NUMBER;
-        const compare = isNumber
-          ? (prev, cur) => {
-            const current = toNumber(cur);
-            return prev <= current ? current : prev;
-          }
-          : (prev, cur) => {
-            const current = toString(cur);
-            return prev.localeCompare(current) === 1 ? prev : current;
-          };
-
-        return array.reduce(compare, isNumber ? toNumber(first) : toString(first));
+        return array.map(a => (isNumber ? toNumber(a) : toString(a)))
+          .sort((a, b) => (a > b ? 1 : -1))
+          .pop();
       },
       _signature: [{ types: [TYPE_ARRAY, TYPE_ARRAY_NUMBER, TYPE_ARRAY_STRING], variadic: true }],
     },
@@ -1032,17 +1024,9 @@ export default function functions(
         if (array.length === 0 || first === undefined) return null;
         // use the first value to determine the comparison type
         const isNumber = getType(first, true) === TYPE_NUMBER;
-        const compare = isNumber
-          ? (prev, cur) => {
-            const current = toNumber(cur);
-            return prev <= current ? prev : current;
-          }
-          : (prev, cur) => {
-            const current = toString(cur);
-            return prev.localeCompare(current) === 1 ? current : prev;
-          };
-
-        return array.reduce(compare, isNumber ? toNumber(first) : toString(first));
+        return array.map(a => (isNumber ? toNumber(a) : toString(a)))
+          .sort((a, b) => (a < b ? 1 : -1))
+          .pop();
       },
       _signature: [{ types: [TYPE_ARRAY, TYPE_ARRAY_NUMBER, TYPE_ARRAY_STRING], variadic: true }],
     },

--- a/test/functions.json
+++ b/test/functions.json
@@ -394,7 +394,7 @@
       },
       {
         "expression": "max(strings, [\"A\", \"B\", \"C\"])",
-        "result": "C"
+        "result": "c"
       },
       {
         "expression": "max([\"D\", \"E\", \"F\"], [\"A\", \"B\", \"C\"])",
@@ -476,7 +476,7 @@
       },
       {
         "expression": "min(strings, [\"A\", \"B\", \"C\"])",
-        "result": "a"
+        "result": "A"
       },
       {
         "expression": "min([\"D\", \"E\", \"F\"], [\"A\", \"B\", \"C\"])",


### PR DESCRIPTION
## Description
The min/max functions used locale-specific comparisons (String.localeCompare()) which was inconsistent with comparison operators and sorting

## Related Issue
https://github.com/adobe/json-formula/issues/114

## Tasks

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.