### PR TITLE
Functions to accept arrays; update coercion rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Given:
 Visit the [Playground](https://opensource.adobe.com/json-formula/dist/index.html)
 
 # Documentation
-Specification / Reference: [HTML](https://opensource.adobe.com/json-formula/doc/output/json-formula-specification-1.1.0.html) / [PDF](https://opensource.adobe.com/json-formula/doc/output/json-formula-specification-1.1.0.pdf)
+Specification / Reference: [HTML](https://opensource.adobe.com/json-formula/doc/output/json-formula-specification-1.1.2.html) / [PDF](https://opensource.adobe.com/json-formula/doc/output/json-formula-specification-1.1.2.pdf)
 
 [JavaScript API](./doc/output/JSDOCS.md)
 

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -76,6 +76,7 @@ If the supplied data is not correct for the execution context, json-formula will
 * The left-hand operand of ordering comparison operators (`>`, `>=`, `<`, `\<=`) must be a string or number.  Any other type shall be coerced to a number.
 * If the operands of an ordering comparison are different, they shall both be coerced to a number
 * Parameters to functions shall be coerced when there is a single viable coercion available.  For example, if a null value is provided to a function that accepts a number or string, then coercion shall not happen, since a null value can be coerced to both types.  Conversely if a string is provided to a function that accepts a number or array of numbers, then the string shall be coerced to a number, since there is no supported coercion to convert it to an array of numbers.
+* When functions accept a typed array, any provided array will have each of its members coerced to the expected type. e.g., if the input array is `[2,3,"6"]` and an array of numbers is expected, the array will be coerced to `[2,3,6]`.
 
 The equality and inequality operators (`=`, `==`, `!=`, `<>`) do **not** perform type coercion.  If operands are different types, the values are considered not equal.
 

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -433,7 +433,7 @@ The numeric and concatenation operators (`+`, `-`, `{asterisk}`, `/`, `&`) have 
 
 * When both operands are arrays, a new array is returned where the elements are populated by applying the operator on each element of the left operand array with the corresponding element from the right operand array
 * If both operands are arrays and they do not have the same size, the shorter array is padded with null values
-* If one operand is an array and one is a scalar value, a new array is returned where the operator is applied with the scalar against each element in the array
+* If one operand is an array and one is a scalar value, the scalar operand will be converted to an array by repeating the value to the same size array as the other operand
 
 [source%unbreakable]
 ----
@@ -1194,26 +1194,42 @@ output.
     return_type function_name2(type1|type2 $argname)
 ----
 
+=== Function parameters
+
 Functions support the set of standard json-formula <<Data Types, data types>>. If the resolved arguments cannot be coerced to
 match the types specified in the signature, a `TypeError` error occurs.
 
 As a shorthand, the type `any` is used to indicate that the function argument can be
-of any of (`array|object|number|string|boolean|null`).
+any of (`array|object|number|string|boolean|null`).
 
 The expression type, (denoted by `&expression`), is used to specify an
 expression that is not immediately evaluated.  Instead, a reference to that
 expression is provided to the function being called.  The function can then apply the expression reference as needed.  It is semantically similar
 to an https://en.wikipedia.org/wiki/Anonymous_function[anonymous function]. See the <<_sortBy, sortBy()>> function for an example of the expression type.
 
-The result of the `functionExpression` is the result returned by the
-function call.  If a `functionExpression` is evaluated for a function that
-does not exist, a `FunctionError` error is raised.
-
-Functions can either have a specific arity or be variadic with a minimum
+Function parameters can either have a specific arity or be variadic with a minimum
 number of arguments.  If a `functionExpression` is encountered where the
 arity does not match, or the minimum number of arguments for a variadic function
 is not provided, or too many arguments are provided, then a
 `FunctionError` error is raised.
+
+The result of the `functionExpression` is the result returned by the
+function call.  If a `functionExpression` is evaluated for a function that
+does not exist, a `FunctionError` error is raised.
+
+Many functions that process scalar values also allow for the processing of arrays of values.  For example, the `round()` function may be called to process a single value: `round(1.2345, 2)` or to process an array of values: `round([1.2345, 2.3456], 2)`.  The first call will return a single value, the second call will return an array of values.
+When processing arrays of values, and where there is more than one parameter, each parameter is converted to an array so that the function processes each value in the set of arrays.  From our example above, the call to `round([1.2345, 2.3456], 2)` would be processed as if it were `round([1.2345, 2.3456], [2, 2])`, and the result would be the same as: `[round(1.2345, 2), round(2.3456, 2)]`.
+
+The rules for the treatment of parameters with arrays of values:
+
+When any parameter is an array then:
+
+* All parameters will be treated as arrays
+* Any scalar parameters will be converted to an array by repeating the scalar value to the length of the longest array
+* All array parameters will be padded to the length of the longest array by adding null values
+* The function will return an array which is the result of iterating over the elements of the arrays and applying the function logic on the values at the same index.
+
+=== Function evaluation
 
 Functions are evaluated in applicative order:
 - Each argument must be an expression

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -76,7 +76,7 @@ If the supplied data is not correct for the execution context, json-formula will
 * The left-hand operand of ordering comparison operators (`>`, `>=`, `<`, `\<=`) must be a string or number.  Any other type shall be coerced to a number.
 * If the operands of an ordering comparison are different, they shall both be coerced to a number
 * Parameters to functions shall be coerced when there is a single viable coercion available.  For example, if a null value is provided to a function that accepts a number or string, then coercion shall not happen, since a null value can be coerced to both types.  Conversely if a string is provided to a function that accepts a number or array of numbers, then the string shall be coerced to a number, since there is no supported coercion to convert it to an array of numbers.
-* When functions accept a typed array, the function rules determine whether coercion may occur.  Some functions (e.g. avg()) ignore array members of the wrong type.  Other functions (e.g. abs()) coerce array members.  If coercion may occur, then any provided array will have each of its members coerced to the expected type. e.g., if the input array is `[2,3,"6"]` and an array of numbers is expected, the array will be coerced to `[2,3,6]`.
+* When functions accept a typed array, the function rules determine whether coercion may occur.  Some functions (e.g. `avg()`) ignore array members of the wrong type.  Other functions (e.g. `abs()`) coerce array members.  If coercion may occur, then any provided array will have each of its members coerced to the expected type. e.g., if the input array is `[2,3,"6"]` and an array of numbers is expected, the array will be coerced to `[2,3,6]`.
 
 The equality and inequality operators (`=`, `==`, `!=`, `<>`) do **not** perform type coercion.  If operands are different types, the values are considered not equal.
 
@@ -117,12 +117,12 @@ In all cases except ordering comparison, if the coercion is not possible, a `Typ
 | string | array | create a single-element array with the string
 | boolean | array | create a single-element array with the boolean
 | object | array | Not supported
-| null | array | Empty array
+| null | array | Not supported
 | number | object | Not supported
 | string | object | Not supported
 | boolean | object | Not supported
 | array | object | Not supported. Use: `fromEntries(entries(array))`
-| null | object | Empty object
+| null | object | Not supported
 | number | boolean | zero is false, all other numbers are true
 | string | boolean | Empty string is false, populated strings are true
 | array | boolean | Empty array is false, populated arrays are true

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -76,7 +76,7 @@ If the supplied data is not correct for the execution context, json-formula will
 * The left-hand operand of ordering comparison operators (`>`, `>=`, `<`, `\<=`) must be a string or number.  Any other type shall be coerced to a number.
 * If the operands of an ordering comparison are different, they shall both be coerced to a number
 * Parameters to functions shall be coerced when there is a single viable coercion available.  For example, if a null value is provided to a function that accepts a number or string, then coercion shall not happen, since a null value can be coerced to both types.  Conversely if a string is provided to a function that accepts a number or array of numbers, then the string shall be coerced to a number, since there is no supported coercion to convert it to an array of numbers.
-* When functions accept a typed array, any provided array will have each of its members coerced to the expected type. e.g., if the input array is `[2,3,"6"]` and an array of numbers is expected, the array will be coerced to `[2,3,6]`.
+* When functions accept a typed array, the function rules determine whether coercion may occur.  Some functions (e.g. avg()) ignore array members of the wrong type.  Other functions (e.g. abs()) coerce array members.  If coercion may occur, then any provided array will have each of its members coerced to the expected type. e.g., if the input array is `[2,3,"6"]` and an array of numbers is expected, the array will be coerced to `[2,3,6]`.
 
 The equality and inequality operators (`=`, `==`, `!=`, `<>`) do **not** perform type coercion.  If operands are different types, the values are considered not equal.
 
@@ -742,8 +742,9 @@ operator follows these processing steps:
 * The result array is returned as a <<Projections,projection>>
 
 Once the flattening operation has been performed, subsequent operations
-are projected onto the flattened array.  The difference between a bracketed wildcard (`[{asterisk}]`) and flatten (`[]`) is that
-flatten will first merge sub-arrays.
+are projected onto the flattened array.
+
+A bracketed wildcard (`[{asterisk}]`) and flatten (`[]`) behave similarly in that they produce a projection from an array. The only difference is that a bracketed wildcard preserves the original array structure while flatten collapses one level of array structure.
 
 [discrete]
 ==== Examples
@@ -1211,7 +1212,7 @@ any of (`array|object|number|string|boolean|null`).
 
 The expression type, (denoted by `&expression`), is used to specify an
 expression that is not immediately evaluated.  Instead, a reference to that
-expression is provided to the function being called.  The function can then apply the expression reference as needed.  It is semantically similar
+expression is provided to the function.  The function can then apply the expression reference as needed.  It is semantically similar
 to an https://en.wikipedia.org/wiki/Anonymous_function[anonymous function]. See the <<_sortBy, sortBy()>> function for an example of the expression type.
 
 Function parameters can either have a specific arity or be variadic with a minimum
@@ -1224,17 +1225,29 @@ The result of the `functionExpression` is the result returned by the
 function call.  If a `functionExpression` is evaluated for a function that
 does not exist, a `FunctionError` error is raised.
 
+==== Array Parameters
 Many functions that process scalar values also allow for the processing of arrays of values.  For example, the `round()` function may be called to process a single value: `round(1.2345, 2)` or to process an array of values: `round([1.2345, 2.3456], 2)`.  The first call will return a single value, the second call will return an array of values.
 When processing arrays of values, and where there is more than one parameter, each parameter is converted to an array so that the function processes each value in the set of arrays.  From our example above, the call to `round([1.2345, 2.3456], 2)` would be processed as if it were `round([1.2345, 2.3456], [2, 2])`, and the result would be the same as: `[round(1.2345, 2), round(2.3456, 2)]`.
 
-The rules for the treatment of parameters with arrays of values:
+Functions that accept array parameters will also accept nested arrays.  With nested arrays, aggregating functions (min(), max(), avg(), sum() etc.) will flatten the arrays. e.g.
 
-When any parameter is an array then:
+`avg([2.1, 3.1, [4.1, 5.1]])` will be processed as `avg([2.1, 3.1, 4.1, 5.1])` and return `3.6`.
+
+Non-aggregating functions will return the same array hierarchy. e.g.
+
+`upper("a", ["b"]]) => ["A", ["B"]]`
+`round([2.12, 3.12, [4.12, 5.12]], 1)` will be processed as `round([2.12, 3.12, [4.12, 5.12]], [1, 1, [1, 1]])` and return `[2.1, 3.1, [4.1, 5.1]] `
+
+These array balancing rules apply when any parameter is an array:
 
 * All parameters will be treated as arrays
 * Any scalar parameters will be converted to an array by repeating the scalar value to the length of the longest array
 * All array parameters will be padded to the length of the longest array by adding null values
 * The function will return an array which is the result of iterating over the elements of the arrays and applying the function logic on the values at the same index.
+
+With nested arrays:
+* Nested arrays will be flattened for aggregating functions
+* Non-aggregating functions will preserve the array hierarchy and will apply the balancing rules to each element of the nested arrays
 
 === Function evaluation
 

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -64,6 +64,8 @@ json-formula functions:
 
 * expression: A string prefixed with an ampersand (`&`) character
 
+This specification uses the term "scalar" to refer to any value that is not an array, object or expression. Scalars include numbers, strings, booleans, and null values.
+
 === Type Coercion
 
 If the supplied data is not correct for the execution context, json-formula will attempt to coerce the data to the correct type. Coercion will occur in these contexts:
@@ -73,7 +75,7 @@ If the supplied data is not correct for the execution context, json-formula will
 * Operands of the union operator (`~`) shall be coerced to an array
 * The left-hand operand of ordering comparison operators (`>`, `>=`, `<`, `\<=`) must be a string or number.  Any other type shall be coerced to a number.
 * If the operands of an ordering comparison are different, they shall both be coerced to a number
-* Parameters to functions shall be coerced when there is just a single viable coercion available.  For example, if a null value is provided to a function that accepts a number or string, then coercion shall not happen, since a null value can be coerced to both types.  Conversely if a string is provided to a function that accepts a number or array of numbers, then the string shall be coerced to a number, since there is no supported coercion to convert it to an array of numbers.
+* Parameters to functions shall be coerced when there is a single viable coercion available.  For example, if a null value is provided to a function that accepts a number or string, then coercion shall not happen, since a null value can be coerced to both types.  Conversely if a string is provided to a function that accepts a number or array of numbers, then the string shall be coerced to a number, since there is no supported coercion to convert it to an array of numbers.
 
 The equality and inequality operators (`=`, `==`, `!=`, `<>`) do **not** perform type coercion.  If operands are different types, the values are considered not equal.
 
@@ -127,7 +129,9 @@ In all cases except ordering comparison, if the coercion is not possible, a `Typ
 | null | boolean | false
 |===
 
-An array may be coerced to another type of array as long as there is a supported coercion for the array content. e.g. just as a string can be coerced to a number, an array of strings may be coerced to an array of numbers.
+An array may be coerced to another type of array as long as there is a supported coercion for the array content. For examples, just as a string can be coerced to a number, an array of strings may be coerced to an array of numbers.
+
+Note that while strings, numbers and booleans may be coerced to arrays, they may not be coerced to a different type within that array. For example, a number cannot be coerced to an array of strings -- even though a number can be coerced to a string, and a string can be coerced to an array of strings.
 
 [discrete]
 ==== Examples
@@ -454,7 +458,7 @@ The union operator (`~`) returns an array formed by concatenating the contents o
   eval(a ~ b, {"a": [[0,1,2]], "b": [[3,4,5]]}) -> [[0,1,2],[3,4,5]]
   eval(a[] ~ b[], {"a": [[0,1,2]], "b": [[3,4,5]]}) -> [0,1,2,3,4,5]
   eval(a ~ 10, {"a": [0,1,2]}) -> [0,1,2,10]
-  eval(a ~ `null`, {"a": [0,1,2]}) -> [0,1,2]
+  eval(a ~ `null`, {"a": [0,1,2]}) -> [0,1,2,null]
 ----
 
 === Boolean Operators

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -73,7 +73,7 @@ If the supplied data is not correct for the execution context, json-formula will
 * Operands of the union operator (`~`) shall be coerced to an array
 * The left-hand operand of ordering comparison operators (`>`, `>=`, `<`, `\<=`) must be a string or number.  Any other type shall be coerced to a number.
 * If the operands of an ordering comparison are different, they shall both be coerced to a number
-* Parameters to functions shall be coerced to the expected type as long as the expected type is a single choice. If the function signature allows multiple types for a parameter e.g. either string or array, then coercion will not occur.
+* Parameters to functions shall be coerced when there is just a single viable coercion available.  For example, if a null value is provided to a function that accepts a number or string, then coercion shall not happen, since a null value can be coerced to both types.  Conversely if a string is provided to a function that accepts a number or array of numbers, then the string shall be coerced to a number, since there is no supported coercion to convert it to an array of numbers.
 
 The equality and inequality operators (`=`, `==`, `!=`, `<>`) do **not** perform type coercion.  If operands are different types, the values are considered not equal.
 
@@ -127,6 +127,8 @@ In all cases except ordering comparison, if the coercion is not possible, a `Typ
 | null | boolean | false
 |===
 
+An array may be coerced to another type of array as long as there is a supported coercion for the array content. e.g. just as a string can be coerced to a number, an array of strings may be coerced to an array of numbers.
+
 [discrete]
 ==== Examples
 
@@ -135,7 +137,7 @@ In all cases except ordering comparison, if the coercion is not possible, a `Typ
     eval("\"$123.00\" + 1", {}) -> TypeError
     eval("truth is " & `true`, {}) -> "truth is true"
     eval(2 + `true`, {}) -> 3
-    eval(avg("20"), {}) -> 20
+    eval(avg(["20", "30"]), {}) -> 25
 ----
 
 === Date and Time Values

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -91,7 +91,7 @@ In all cases except ordering comparison, if the coercion is not possible, a `Typ
     eval([1,2,3] ~ 4, {}) -> [1,2,3,4]
     eval(123 < "124", {}) -> true
     eval("23" > 111, {}) -> false
-    eval(abs("-2"), {}) -> 2
+    eval(avg(["2", "3", "4"]), {}) -> 3
     eval(1 == "1", {}) -> false
 ----
 

--- a/src/functions.js
+++ b/src/functions.js
@@ -2310,7 +2310,12 @@ export default function functions(
         try {
           return toNumber(num);
         } catch (e) {
-          debug.push(`Failed to convert "${num}" to number`);
+          const errorString = arg => {
+            const v = toJSON(arg);
+            return v.length > 50 ? `${v.substring(0, 20)} ...` : v;
+          };
+
+          debug.push(`Failed to convert "${errorString(num)}" to number`);
           return null;
         }
       },

--- a/src/functions.js
+++ b/src/functions.js
@@ -358,8 +358,8 @@ export default function functions(
     // and if not provided is assumed to be false.
     /**
      * Find the absolute (non-negative) value of the provided argument `value`.
-     * @param {number} value a numeric value
-     * @return {number} If `value < 0`, returns `-value`, otherwise returns `value`
+     * @param {number|number[]} value A numeric value
+     * @return {number|number[]} If `value < 0`, returns `-value`, otherwise returns `value`
      * @function abs
      * @example
      * abs(-1) // returns 1
@@ -370,9 +370,9 @@ export default function functions(
     },
     /**
      * Compute the inverse cosine (in radians) of a number.
-     * @param {number} cosine A number between -1 and 1, inclusive,
+     * @param {number|number[]} cosine A number between -1 and 1, inclusive,
      * representing the angle's cosine value.
-     * @return {number} The inverse cosine angle in radians between 0 and PI
+     * @return {number|number[]} The inverse cosine angle in radians between 0 and PI
      * @function acos
      * @example
      * acos(0) => 1.5707963267948966
@@ -407,9 +407,9 @@ export default function functions(
 
     /**
      * Compute the inverse sine (in radians) of a number.
-     * @param {number} sine A number between -1 and 1, inclusive,
+     * @param {number|number[]} sine A number between -1 and 1, inclusive,
      * representing the angle's sine value.
-     * @return {number} The inverse sine angle in radians between -PI/2 and PI/2
+     * @return {number|number[]} The inverse sine angle in radians between -PI/2 and PI/2
      * @function asin
      * @example
      * Math.asin(0) => 0
@@ -422,9 +422,9 @@ export default function functions(
     /**
      * Compute the angle in the plane (in radians) between the positive
      * x-axis and the ray from (0, 0) to the point (x, y)
-     * @param {number} y The y coordinate of the point
-     * @param {number} x The x coordinate of the point
-     * @return {number} The angle in radians (between -PI and PI),
+     * @param {number|number[]} y The y coordinate of the point
+     * @param {number|number[]} x The x coordinate of the point
+     * @return {number|number[]} The angle in radians (between -PI and PI),
      * between the positive x-axis and the ray from (0, 0) to the point (x, y).
      * @function atan2
      * @example
@@ -463,8 +463,8 @@ export default function functions(
     /**
      * Generates a lower-case string of the `input` string using locale-specific mappings.
      * e.g. Strings with German letter <span>&#223;</span> (eszett) can be compared to "ss"
-     * @param {string} input string to casefold
-     * @returns {string} A new string converted to lower case
+     * @param {string|string[]} input string to casefold
+     * @returns {string|string[]} A new string converted to lower case
      * @function casefold
      * @example
      * casefold("AbC") // returns "abc"
@@ -481,8 +481,8 @@ export default function functions(
     /**
      * Finds the next highest integer value of the argument `num` by rounding up if necessary.
      * i.e. ceil() rounds toward positive infinity.
-     * @param {number} num numeric value
-     * @return {integer} The smallest integer greater than or equal to num
+     * @param {number|number[]} num numeric value
+     * @return {integer|integer[]} The smallest integer greater than or equal to num
      * @function ceil
      * @example
      * ceil(10) // returns 10
@@ -495,8 +495,9 @@ export default function functions(
     },
     /**
      * Retrieve the first code point from a string
-     * @param {string} str source string.
-     * @return {integer} Unicode code point value. If the input string is empty, returns `null`.
+     * @param {string|string[]} str source string.
+     * @return {integer|integer[]} Unicode code point value.
+     * If the input string is empty, returns `null`.
      * @function codePoint
      * @example
      * codePoint("ABC") // 65
@@ -553,8 +554,8 @@ export default function functions(
     },
     /**
      * Compute the cosine (in radians) of a number.
-     * @param {number} angle A number representing an angle in radians
-     * @return {number} The cosine of the angle, between -1 and 1, inclusive.
+     * @param {number|number[]} angle A number representing an angle in radians
+     * @return {number|number[]} The cosine of the angle, between -1 and 1, inclusive.
      * @function cos
      * @example
      * cos(1.0471975512) => 0.4999999999970535
@@ -575,15 +576,15 @@ export default function functions(
      * after subtracting whole years.
      * * `yd` the number of days between `start_date` and `end_date`, assuming `start_date`
      * and `end_date` were no more than one year apart
-     * @param {number} start_date The starting <<_date_and_time_values, date/time value>>.
+     * @param {number|number[]} start_date The starting <<_date_and_time_values, date/time value>>.
      * Date/time values can be generated using the
      * [datetime]{@link datetime}, [toDate]{@link todate}, [today]{@link today}, [now]{@link now}
      * and [time]{@link time} functions.
-     * @param {number} end_date The end <<_date_and_time_values, date/time value>> -- must
+     * @param {number|number[]} end_date The end <<_date_and_time_values, date/time value>> -- must
      * be greater or equal to start_date. If not, an error will be thrown.
-     * @param {string} unit Case-insensitive string representing the unit of time to measure.
-     * An unrecognized unit will result in an error.
-     * @returns {integer} The number of days/months/years difference
+     * @param {string|string[]} unit Case-insensitive string representing the unit of
+     * time to measure.  An unrecognized unit will result in an error.
+     * @returns {integer|integer[]} The number of days/months/years difference
      * @function datedif
      * @example
      * datedif(datetime(2001, 1, 1), datetime(2003, 1, 1), "y") // returns 2
@@ -654,10 +655,10 @@ export default function functions(
 
     /**
      * Finds the day of the month for a date value
-     * @param {number} date <<_date_and_time_values, date/time value>> generated using the
+     * @param {number|number[]} date <<_date_and_time_values, date/time value>> generated using the
      * [datetime]{@link datetime}, [toDate]{@link todate}, [today]{@link today}, [now]{@link now}
      * and [time]{@link time} functions.
-     * @return {integer} The day of the month ranging from 1 to 31.
+     * @return {integer|integer[]} The day of the month ranging from 1 to 31.
      * @function day
      * @example
      * day(datetime(2008,5,23)) // returns 23
@@ -746,9 +747,9 @@ export default function functions(
 
     /**
      * Determines if the `subject` string ends with a specific `suffix`
-     * @param {string} subject source string in which to search
-     * @param {string} suffix search string
-     * @return {boolean} true if the `suffix` value is at the end of the `subject`
+     * @param {string|string[]} subject source string in which to search
+     * @param {string|string[]} suffix search string
+     * @return {boolean|boolean[]} true if the `suffix` value is at the end of the `subject`
      * @function endsWith
      * @example
      * endsWith("Abcd", "d") // returns true
@@ -790,12 +791,12 @@ export default function functions(
 
     /**
      * Finds the date value of the end of a month, given `startDate` plus `monthAdd` months
-     * @param {number} startDate The base date to start from.
+     * @param {number|number[]} startDate The base date to start from.
      * <<_date_and_time_values, Date/time values>> can be generated using the
      * [datetime]{@link datetime}, [toDate]{@link todate}, [today]{@link today}, [now]{@link now}
      * and [time]{@link time} functions.
-     * @param {integer} monthAdd Number of months to add to start date
-     * @return {number} the date of the last day of the month
+     * @param {integer|integer[]} monthAdd Number of months to add to start date
+     * @return {number|number[]} the date of the last day of the month
      * @function eomonth
      * @example
      * eomonth(datetime(2011, 1, 1), 1) | [month(@), day(@)] // returns [2, 28]
@@ -811,8 +812,8 @@ export default function functions(
 
     /**
      * Finds e (the base of natural logarithms) raised to a power. (i.e. e^x)
-     * @param {number} x A numeric expression representing the power of e.
-     * @returns {number} e (the base of natural logarithms) raised to power x
+     * @param {number|number[]} x A numeric expression representing the power of e.
+     * @returns {number|number[]} e (the base of natural logarithms) raised to power x
      * @function exp
      * @example
      * exp(10) // returns 22026.465794806718
@@ -837,11 +838,11 @@ export default function functions(
 
     /**
      * Finds and returns the index of query in text from a start position
-     * @param {string} findText string to search
-     * @param {string} withinText text to be searched
-     * @param {integer} [start=0] zero-based position to start searching.
+     * @param {string|string[]} findText string to search
+     * @param {string|string[]} withinText text to be searched
+     * @param {integer|integer[]} [start=0] zero-based position to start searching.
      * If specified, `start` must be greater than or equal to 0
-     * @returns {integer|null} The position of the found string, null if not found.
+     * @returns {integer|null|integer[]} The position of the found string, null if not found.
      * @function find
      * @example
      * find("m", "abm") // returns 2
@@ -865,8 +866,8 @@ export default function functions(
     /**
      * Calculates the next lowest integer value of the argument `num` by rounding down if necessary.
      * i.e. floor() rounds toward negative infinity.
-     * @param {number} num numeric value
-     * @return {integer} The largest integer smaller than or equal to num
+     * @param {number|number[]} num numeric value
+     * @return {integer|integer[]} The largest integer smaller than or equal to num
      * @function floor
      * @example
      * floor(10.4) // returns 10
@@ -879,9 +880,9 @@ export default function functions(
 
     /**
      * Create a string from a code point.
-     * @param {integer} codePoint An integer between 0 and 0x10FFFF (inclusive)
-     * representing a Unicode code point.
-     * @return {string} A string from a given code point
+     * @param {integer|integer[]} codePoint An integer or array of integers
+     * between 0 and 0x10FFFF (inclusive) representing Unicode code point(s).
+     * @return {string} A string from the given code point(s)
      * @function fromCodePoint
      * @example
      * fromCodePoint(65) // "A"
@@ -934,8 +935,8 @@ export default function functions(
 
     /**
      * Compute the nearest 32-bit single precision float representation of a number
-     * @param {number} num input to be rounded
-     * @return {number} The rounded representation of `num`
+     * @param {number|number[]} num input to be rounded
+     * @return {number|number[]} The rounded representation of `num`
      * @function fround
      * @example
      * fround(2147483650.987) => 2147483648
@@ -988,11 +989,11 @@ export default function functions(
     },
     /**
      * Extract the hour from a <<_date_and_time_values, date/time value>>
-     * @param {number} date The datetime/time for which the hour is to be returned.
+     * @param {number|number[]} date The datetime/time for which the hour is to be returned.
      * Date/time values can be generated using the
      * [datetime]{@link datetime}, [toDate]{@link todate}, [today]{@link today}, [now]{@link now}
      * and [time]{@link time} functions.
-     * @return {integer} value between 0 and 23
+     * @return {integer|integer[]} value between 0 and 23
      * @function hour
      * @example
      * hour(datetime(2008,5,23,12, 0, 0)) // returns 12
@@ -1133,8 +1134,8 @@ export default function functions(
 
     /**
      * Compute the natural logarithm (base e) of a number
-     * @param {number} num A number greater than zero
-     * @return {number} The natural log value
+     * @param {number|number[]} num A number greater than zero
+     * @return {number|number[]} The natural log value
      * @function log
      * @example
      * log(10) // 2.302585092994046
@@ -1146,8 +1147,8 @@ export default function functions(
 
     /**
      * Compute the base 10 logarithm of a number.
-     * @param {number} num A number greater than or equal to zero
-     * @return {number} The base 10 log result
+     * @param {number|number[]} num A number greater than or equal to zero
+     * @return {number|number[]} The base 10 log result
      * @function log10
      * @example
      * log10(100000) // 5
@@ -1159,8 +1160,8 @@ export default function functions(
 
     /**
      * Converts all the alphabetic code points in a string to lowercase.
-     * @param {string} input input string
-     * @returns {string} the lower case value of the input string
+     * @param {string|string[]} input input string
+     * @returns {string|string[]} the lower case value of the input string
      * @function lower
      * @example
      * lower("E. E. Cummings") // returns e. e. cummings
@@ -1290,11 +1291,11 @@ export default function functions(
 
     /**
      * Extract the milliseconds of the time value in a <<_date_and_time_values, date/time value>>.
-     * @param {number} date datetime/time for which the millisecond is to be returned.
+     * @param {number|number[]} date datetime/time for which the millisecond is to be returned.
      * Date/time values can be generated using the
      * [datetime]{@link datetime}, [toDate]{@link todate}, [today]{@link today}, [now]{@link now}
      * and [time]{@link time} functions.
-     * @return {integer} The number of milliseconds: 0 through 999
+     * @return {integer|integer[]} The number of milliseconds: 0 through 999
      * @function millisecond
      * @example
      * millisecond(datetime(2008, 5, 23, 12, 10, 53, 42)) // returns 42
@@ -1343,11 +1344,11 @@ export default function functions(
 
     /**
      * Extract the minute (0 through 59) from a <<_date_and_time_values, date/time value>>
-     * @param {number} date A datetime/time value.
+     * @param {number|number[]} date A datetime/time value.
      * Date/time values can be generated using the
      * [datetime]{@link datetime}, [toDate]{@link todate}, [today]{@link today}, [now]{@link now}
      * and [time]{@link time} functions.
-     * @return {integer} Number of minutes in the time portion of the date/time value
+     * @return {integer|integer[]} Number of minutes in the time portion of the date/time value
      * @function minute
      * @example
      * minute(datetime(2008,5,23,12, 10, 0)) // returns 10
@@ -1362,9 +1363,9 @@ export default function functions(
 
     /**
      * Return the remainder when one number is divided by another number.
-     * @param {number} dividend The number for which to find the remainder.
-     * @param {number} divisor The number by which to divide number.
-     * @return {number} Computes the remainder of `dividend`/`divisor`.
+     * @param {number|number[]} dividend The number for which to find the remainder.
+     * @param {number|number[]} divisor The number by which to divide number.
+     * @return {number|number[]} Computes the remainder of `dividend`/`divisor`.
      * If `dividend` is negative, the result will also be negative.
      * If `dividend` is zero, an error is thrown.
      * @function mod
@@ -1386,11 +1387,11 @@ export default function functions(
 
     /**
      * Finds the month of a date.
-     * @param {number} date source <<_date_and_time_values, date/time value>>.
+     * @param {number|number[]} date source <<_date_and_time_values, date/time value>>.
      * Date/time values can be generated using the
      * [datetime]{@link datetime}, [toDate]{@link todate}, [today]{@link today}, [now]{@link now}
      * and [time]{@link time} functions.
-     * @return {integer} The month number value, ranging from 1 (January) to 12 (December).
+     * @return {integer|integer[]} The month number value, ranging from 1 (January) to 12 (December)
      * @function month
      * @example
      * month(datetime(2008,5,23)) // returns 5
@@ -1486,9 +1487,9 @@ export default function functions(
 
     /**
      * Computes `a` raised to a power `x`. (a^x)
-     * @param {number} a The base number -- can be any real number.
-     * @param {number} x The exponent to which the base number is raised.
-     * @return {number}
+     * @param {number|number[]} a The base number -- can be any real number.
+     * @param {number|number[]} x The exponent to which the base number is raised.
+     * @return {number|number[]}
      * @function power
      * @example
      * power(10, 2) // returns 100 (10 raised to power 2)
@@ -1507,8 +1508,8 @@ export default function functions(
      * uppercase letter and the rest of the letters in the word converted to lowercase.
      * Words are demarcated by whitespace, punctuation, or numbers.
      * Specifically, any character(s) matching the regular expression: `[\s\d\p{P}]+`.
-     * @param {string} text source string
-     * @returns {string} source string with proper casing applied.
+     * @param {string|string[]} text source string
+     * @returns {string|string[]} source string with proper casing applied.
      * @function proper
      * @example
      * proper("this is a TITLE") // returns "This Is A Title"
@@ -1670,10 +1671,10 @@ export default function functions(
 
     /**
      * Return text repeated `count` times.
-     * @param {string} text text to repeat
-     * @param {integer} count number of times to repeat the text.
+     * @param {string|string[]} text text to repeat
+     * @param {integer|integer[]} count number of times to repeat the text.
      * Must be greater than or equal to 0.
-     * @returns {string} Text generated from the repeated text.
+     * @returns {string|string[]} Text generated from the repeated text.
      * if `count` is zero, returns an empty string.
      * @function rept
      * @example
@@ -1745,9 +1746,9 @@ export default function functions(
      * * If `precision` is greater than zero, round to the specified number of decimal places.
      * * If `precision` is 0, round to the nearest integer.
      * * If `precision` is less than 0, round to the left of the decimal point.
-     * @param {number} num number to round
-     * @param {integer} [precision=0] precision to use for the rounding operation.
-     * @returns {number} rounded value. Rounding a half value will round up.
+     * @param {number|number[]} num number to round
+     * @param {integer|integer[]} [precision=0] precision to use for the rounding operation.
+     * @returns {number|number[]} rounded value. Rounding a half value will round up.
      * @function round
      * @example
      * round(2.15, 1) // returns 2.2
@@ -1780,9 +1781,10 @@ export default function functions(
      * precede them with an escape (`{backslash}`) character.
      * Note that the wildcard search is not greedy.
      * e.g. `search("a{asterisk}b", "abb")` will return `[0, "ab"]` Not `[0, "abb"]`
-     * @param {string} findText the search string -- which may include wild cards.
-     * @param {string} withinText The string to search.
-     * @param {integer} [startPos=0] The zero-based position of withinText to start searching.
+     * @param {string|string[]} findText the search string -- which may include wild cards.
+     * @param {string|string[]} withinText The string to search.
+     * @param {integer|integer[]} [startPos=0] The zero-based position of withinText
+     * to start searching.
      * A negative value is not allowed.
      * @returns {array} returns an array with two values:
      *
@@ -1808,11 +1810,11 @@ export default function functions(
 
     /**
      * Extract the seconds of the time value in a <<_date_and_time_values, date/time value>>.
-     * @param {number} date datetime/time for which the second is to be returned.
+     * @param {number|number[]} date datetime/time for which the second is to be returned.
      * Date/time values can be generated using the
      * [datetime]{@link datetime}, [toDate]{@link todate}, [today]{@link today}, [now]{@link now}
      * and [time]{@link time} functions.
-     * @return {integer} The number of seconds: 0 through 59
+     * @return {integer|integer[]} The number of seconds: 0 through 59
      * @function second
      * @example
      * second(datetime(2008,5,23,12, 10, 53)) // returns 53
@@ -1827,8 +1829,8 @@ export default function functions(
 
     /**
      * Computes the sign of a number passed as argument.
-     * @param {number} num any number
-     * @return {number} returns 1 or -1, indicating the sign of `num`.
+     * @param {number|number[]} num any number
+     * @return {number|number[]} returns 1 or -1, indicating the sign of `num`.
      * If the `num` is 0, it will return 0.
      * @function sign
      * @example
@@ -1843,8 +1845,8 @@ export default function functions(
 
     /**
      * Computes the sine of a number in radians
-     * @param {number} angle A number representing an angle in radians.
-     * @return {number} The sine of `angle`, between -1 and 1, inclusive
+     * @param {number|number[]} angle A number representing an angle in radians.
+     * @return {number|number[]} The sine of `angle`, between -1 and 1, inclusive
      * @function sin
      * @example
      * sin(0) // 0
@@ -1953,9 +1955,9 @@ export default function functions(
 
     /**
      * Split a string into an array, given a separator
-     * @param {string} string string to split
-     * @param {string} separator separator where the split(s) should occur
-     * @return {string[]} The array of separated strings
+     * @param {string|string[]} string string to split
+     * @param {string|string[]} separator separator where the split(s) should occur
+     * @return {string[]|string[][]} The array of separated strings
      * @function split
      * @example
      * split("abcdef", "") // returns ["a", "b", "c", "d", "e", "f"]
@@ -1971,8 +1973,8 @@ export default function functions(
 
     /**
          * Find the square root of a number
-         * @param {number} num source number
-         * @return {number} The calculated square root value
+         * @param {number|number[]} num source number
+         * @return {number|number[]} The calculated square root value
          * @function sqrt
          * @example
          * sqrt(4) // returns 2
@@ -1986,9 +1988,9 @@ export default function functions(
 
     /**
      * Determine if a string starts with a prefix.
-     * @param {string} subject string to search
-     * @param {string} prefix prefix to search for
-     * @return {boolean} true if `prefix` matches the start of `subject`
+     * @param {string|string[]} subject string to search
+     * @param {string|string[]} prefix prefix to search for
+     * @return {boolean|boolean[]} true if `prefix` matches the start of `subject`
      * @function startsWith
      * @example
      * startsWith("jack is at home", "jack") // returns true
@@ -2060,13 +2062,14 @@ export default function functions(
      * with text `old` replaced by text `new` (when searching from the left).
      * If there is no match, or if `old` has length 0, `text` is returned unchanged.
      * Note that `old` and `new` may have different lengths.
-     * @param {string} text The text for which to substitute code points.
-     * @param {string} old The text to replace.
-     * @param {string} new The text to replace `old` with.  If `new` is an empty string, then
-     * occurrences of `old` are removed from `text`.
-     * @param {integer} [which] The zero-based occurrence of `old` text to replace with `new` text.
+     * @param {string|string[]} text The text for which to substitute code points.
+     * @param {string|string[]} old The text to replace.
+     * @param {string|string[]} new The text to replace `old` with.
+     * If `new` is an empty string, then occurrences of `old` are removed from `text`.
+     * @param {integer|integer[]} [which]
+     * The zero-based occurrence of `old` text to replace with `new` text.
      * If `which` parameter is omitted, every occurrence of `old` is replaced with `new`.
-     * @returns {string} replaced string
+     * @returns {string|string[]} replaced string
      * @function substitute
      * @example
      * substitute("Sales Data", "Sales", "Cost") // returns "Cost Data"
@@ -2118,8 +2121,8 @@ export default function functions(
     },
     /**
      * Computes the tangent of a number in radians
-     * @param {number} angle A number representing an angle in radians.
-     * @return {number} The tangent of `angle`
+     * @param {number|number[]} angle A number representing an angle in radians.
+     * @return {number|number[]} The tangent of `angle`
      * @function tan
      * @example
      * tan(0) // 0
@@ -2340,8 +2343,8 @@ export default function functions(
     /**
      * Remove leading and trailing spaces (U+0020), and replace all internal multiple spaces
      * with a single space.  Note that other whitespace characters are left intact.
-     * @param {string} text string to trim
-     * @return {string} trimmed string
+     * @param {string|string[]} text string to trim
+     * @return {string|string[]} trimmed string
      * @function trim
      * @example
      * trim("   ab    c   ") // returns "ab c"
@@ -2367,9 +2370,10 @@ export default function functions(
     /**
      * Truncates a number to an integer by removing the fractional part of the number.
      * i.e. it rounds towards zero.
-     * @param {number} numA number to truncate
-     * @param {integer} [numB=0] A number specifying the number of decimal digits to preserve.
-     * @return {number} Truncated value
+     * @param {number|number[]} numA number to truncate
+     * @param {integer|integer[]} [numB=0]
+     * A number specifying the number of decimal digits to preserve.
+     * @return {number|number[]} Truncated value
      * @function trunc
      * @example
      * trunc(8.9) // returns 8
@@ -2450,8 +2454,8 @@ export default function functions(
 
     /**
      * Converts all the alphabetic code points in a string to uppercase.
-     * @param {string} input input string
-     * @returns {string} the upper case value of the input string
+     * @param {string|string[]} input input string
+     * @returns {string|string[]} the upper case value of the input string
      * @function upper
      * @example
      * upper("abcd") // returns "ABCD"
@@ -2537,15 +2541,15 @@ export default function functions(
      * * 1 : Sunday (1), Monday (2), ..., Saturday (7)
      * * 2 : Monday (1), Tuesday (2), ..., Sunday(7)
      * * 3 : Monday (0), Tuesday (1), ...., Sunday(6)
-     * @param {number} date <<_date_and_time_values, date/time value>> for
+     * @param {number|number[]} date <<_date_and_time_values, date/time value>> for
      * which the day of the week is to be returned.
      * Date/time values can be generated using the
      * [datetime]{@link datetime}, [toDate]{@link todate}, [today]{@link today}, [now]{@link now}
      * and [time]{@link time} functions.
-     * @param {integer} [returnType=1] Determines the
+     * @param {integer|integer[]} [returnType=1] Determines the
      * representation of the result.
      * An unrecognized returnType will result in a error.
-     * @returns {integer} day of the week
+     * @returns {integer|integer[]} day of the week
      * @function weekday
      * @example
      * weekday(datetime(2006,5,21)) // 1
@@ -2566,11 +2570,11 @@ export default function functions(
 
     /**
      * Finds the year of a datetime value
-     * @param {number} date input <<_date_and_time_values, date/time value>>
+     * @param {number|number[]} date input <<_date_and_time_values, date/time value>>
      * Date/time values can be generated using the
      * [datetime]{@link datetime}, [toDate]{@link todate}, [today]{@link today}, [now]{@link now}
      * and [time]{@link time} functions.
-     * @return {integer} The year value
+     * @return {integer|integer[]} The year value
      * @function year
      * @example
      * year(datetime(2008,5,23)) // returns 2008

--- a/src/functions.js
+++ b/src/functions.js
@@ -795,8 +795,8 @@ export default function functions(
     endsWith: {
       _func: args => evaluate(args, endsWithFn),
       _signature: [
-        { types: [TYPE_STRING, TYPE_ARRAY] },
-        { types: [TYPE_STRING, TYPE_ARRAY] },
+        { types: [TYPE_STRING, TYPE_ARRAY_STRING] },
+        { types: [TYPE_STRING, TYPE_ARRAY_STRING] },
       ],
     },
 
@@ -957,6 +957,7 @@ export default function functions(
         const array = args[0];
         // validate beyond the TYPE_ARRAY_ARRAY check
         if (!array.every(a => {
+          if (!Array.isArray(a)) return false;
           if (a.length !== 2) return false;
           if (getType(a[0]) !== TYPE_STRING) return false;
           return true;
@@ -966,7 +967,7 @@ export default function functions(
         return Object.fromEntries(array);
       },
       _signature: [
-        { types: [TYPE_ARRAY_ARRAY] },
+        { types: [TYPE_ARRAY_ARRAY, TYPE_ARRAY_STRING, TYPE_ARRAY_NUMBER] },
       ],
     },
 
@@ -1038,9 +1039,7 @@ export default function functions(
      */
     hour: {
       _func: args => evaluate(args, a => getDateObj(a).getHours()),
-      _signature: [
-        { types: [TYPE_NUMBER, TYPE_ARRAY_NUMBER] },
-      ],
+      _signature: [{ types: [TYPE_NUMBER, TYPE_ARRAY_NUMBER] }],
     },
 
     /**
@@ -2322,7 +2321,7 @@ export default function functions(
     sum: {
       _func: resolvedArgs => {
         let sum = 0;
-        resolvedArgs[0].forEach(arg => {
+        resolvedArgs[0].flat(Infinity).forEach(arg => {
           sum += arg * 1;
         });
         return sum;

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -116,7 +116,7 @@ class Runtime {
     const argsNeeded = signature.filter(arg => !arg.optional).length;
     const lastArg = signature[signature.length - 1];
     if (lastArg.variadic) {
-      if (args.length < signature.length) {
+      if (args.length < signature.length && !lastArg.optional) {
         pluralized = signature.length === 1 ? ' argument' : ' arguments';
         throw functionError(`${argName}() takes at least ${signature.length}${pluralized
         } but received ${args.length}`);

--- a/src/matchType.js
+++ b/src/matchType.js
@@ -172,6 +172,7 @@ export function matchType(expectedList, argValue, context, toNumber, toString) {
   if (isObject(actual) && expected === TYPE_BOOLEAN) {
     return Object.keys(argValue).length === 0;
   }
+
   // no exact match, see if we can coerce an array type
   if (isArray(actual)) {
     const toArray = a => (Array.isArray(a) ? a : [a]);

--- a/src/matchType.js
+++ b/src/matchType.js
@@ -115,12 +115,6 @@ function supportedConversion(from, to) {
     [TYPE_NULL]: [
       TYPE_STRING,
       TYPE_NUMBER,
-      TYPE_EMPTY_ARRAY,
-      TYPE_ARRAY_STRING,
-      TYPE_ARRAY_NUMBER,
-      TYPE_ARRAY_ARRAY,
-      TYPE_ARRAY,
-      TYPE_OBJECT,
       TYPE_BOOLEAN,
     ],
     [TYPE_STRING]: [
@@ -188,14 +182,12 @@ export function matchType(expectedList, argValue, context, toNumber, toString) {
   }
 
   if (!isArray(actual) && !isObject(actual)) {
-    if (expected === TYPE_ARRAY_STRING) return actual === TYPE_NULL ? [] : [toString(argValue)];
-    if (expected === TYPE_ARRAY_NUMBER) return actual === TYPE_NULL ? [] : [toNumber(argValue)];
-    if (expected === TYPE_ARRAY) return actual === TYPE_NULL ? [] : [argValue];
-    if ([TYPE_ARRAY_ARRAY, TYPE_EMPTY_ARRAY].includes(expected) && actual === TYPE_NULL) return [];
+    if (expected === TYPE_ARRAY_STRING) return [toString(argValue)];
+    if (expected === TYPE_ARRAY_NUMBER) return [toNumber(argValue)];
+    if (expected === TYPE_ARRAY) return [argValue];
     if (expected === TYPE_NUMBER) return toNumber(argValue);
     if (expected === TYPE_STRING) return toString(argValue);
     if (expected === TYPE_BOOLEAN) return !!argValue;
-    if (expected === TYPE_OBJECT && actual === TYPE_NULL) return {};
   }
 
   throw typeError(`${context} expected argument to be type ${typeNameTable[expected]} but received type ${typeNameTable[actual]} instead.`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -108,13 +108,15 @@ export function getProperty(obj, key) {
   return undefined;
 }
 
-export function debugAvailable(debug, obj, key) {
+export function debugAvailable(debug, obj, key, chainStart = null) {
   try {
-    debug.push(`Failed to find: '${key}'`);
     let available = [];
     if (isArray(obj) && obj.length > 0) {
-      available.push(`${0}..${obj.length - 1}`);
+      debug.push(`Failed to find: '${key}' on an array object.`);
+      debug.push(`Did you mean to use a projection? e.g. ${chainStart || 'array'}[*].${key}`);
+      return;
     }
+    debug.push(`Failed to find: '${key}'`);
     if (obj !== null) {
       available = [...available, ...Object.entries(Object.getOwnPropertyDescriptors(obj, key))
         .filter(([k, desc]) => (desc?.enumerable || !!desc?.get) && !/^[0-9]+$/.test(k) && (!k.startsWith('$') || key.startsWith('$')))

--- a/test/docSamples.json
+++ b/test/docSamples.json
@@ -230,6 +230,26 @@
         "result": 42
       },
       {
+        "data": "registerWithParams(\"Product\", &@[0] * @[1])",
+        "expression": "registerWithParams(\"Product\", &@[0] * @[1]) | Product(2, 21)",
+        "result": 42
+      },
+      {
+        "data": "register(\"_ltrim\", &split(@,\"\").reduce(@, &accumulated & current | if(@ = \" \", \"\", @), \"\")) | _ltrim(\"  abc  \")",
+        "expression": "register(\"_ltrim\", &split(@,\"\").reduce(@, &accumulated & current | if(@ = \" \", \"\", @), \"\")) | _ltrim(\"  abc  \")",
+        "result": "abc  "
+      },
+      {
+        "data": "registerWithParams(\"Product\", &@[0] * @[1])",
+        "expression": "registerWithParams(\"Product\", &@[0] * @[1]) | Product(2, 21)",
+        "result": 42
+      },
+      {
+        "data": "registerWithParams(\"Ltrim\", &split(@[0],\"\").reduce(@, &accumulated & current | if(@ = \" \", \"\", @), \"\")) | Ltrim(\"  abc  \")",
+        "expression": "registerWithParams(\"Ltrim\", &split(@[0],\"\").reduce(@, &accumulated & current | if(@ = \" \", \"\", @), \"\")) | Ltrim(\"  abc  \")",
+        "result": "abc  "
+      },
+      {
         "expression": "reverse([\"a\", \"b\", \"c\"])",
         "result": ["c", "b", "a"]
       },

--- a/test/docSamples.json
+++ b/test/docSamples.json
@@ -148,12 +148,36 @@
         "result": 7
       },
       {
-        "expression": "max([\"a\", \"a1\", \"b\"])",
-        "result": "b"
+        "expression": "max([\"a\", \"a1\", \"b\"], null(), true())",
+        "result": 0
       },
       {
         "expression": "max(8, 10, 12)",
         "result": 12
+      },
+      {
+        "expression": "maxA([1, 2, 3], [4, 5, 6])",
+        "result": 6
+      },
+      {
+        "expression": "maxA([\"a\", \"a1\", \"b\", null()])",
+        "error": "TypeError"
+      },
+      {
+        "expression": "maxA(8, 10, 12, \"14\")",
+        "result": 14
+      },
+      {
+        "expression": "minA([1, 2, 3], [4, 5, 6])",
+        "result": 1
+      },
+      {
+        "expression": "minA(\"4\", 8, 10, 12, null())",
+        "result": 4
+      },
+      {
+        "expression": "avgA([1, 2, \"3\", null()])",
+        "result": 2
       },
       {
         "expression": "merge({a: 1, b: 2}, {c : 3, d: 4})",
@@ -173,12 +197,12 @@
         }
       },
       {
-        "expression": "min([1, 2, 3], [4, 5, 6], 7)",
+        "expression": "min([1, 2, 3], [4, 5, 6], 7, false())",
         "result": 1
       },
       {
         "expression": "min([\"a\", \"a1\", \"b\"])",
-        "result": "a"
+        "result": 0
       },
       {
         "expression": "min(8, 10, 12)",
@@ -212,6 +236,10 @@
       {
         "expression": "sort([1, 2, 4, 3, 1])",
         "result": [1, 1, 2, 3, 4]
+      },
+      {
+        "expression": "sort([\"20\", 20, true(), \"100\", null(), 100])",
+        "result": [20, 100, "100", "20", true, null]
       },
       {
         "expression": "sortBy([\"abcd\", \"e\", \"def\"], &length(@))",
@@ -572,7 +600,15 @@
         "result": 27.79688231918724
       },
       {
-        "expression": "stdev([1345, 1301, 1368])",
+        "expression": "stdevA([1345, 1301, 1368])",
+        "result": 34.044089061098404
+      },
+      {
+        "expression": "stdevpA([1345, \"1301\", 1368])",
+        "result": 27.79688231918724
+      },
+      {
+        "expression": "stdevA([1345, 1301, \"1368\"])",
         "result": 34.044089061098404
       },
       {

--- a/test/extensions.spec.js
+++ b/test/extensions.spec.js
@@ -140,8 +140,8 @@ test('debug output', () => {
 
   expect(debug).toEqual([
     'Index: 10 out of range for array size: 6',
-    'Failed to find: \'$values\'',
-    'Available fields: 0..5,\'$name\',\'$fields\',\'$value\'',
+    'Failed to find: \'$values\' on an array object.',
+    'Did you mean to use a projection? e.g. array[*].$values',
     'Failed to find: \'foo\'',
     'Available fields: \'array1\',\'prop\'',
     'Failed to find: \'$readOnly\'',

--- a/test/functions.json
+++ b/test/functions.json
@@ -57,9 +57,18 @@
         "expression": "hasProperty(@, \"null_key\")",
         "result": true
       },
-      { "expression": "hasProperty(`false`, \"key\")", "error": "TypeError"},
-      { "expression": "hasProperty(42, \"key\")", "error": "TypeError"},
-      { "expression": "hasProperty(\"abc\", \"key\")", "error": "TypeError"},
+      {
+        "expression": "hasProperty(`false`, \"key\")",
+        "error": "TypeError"
+      },
+      {
+        "expression": "hasProperty(42, \"key\")",
+        "error": "TypeError"
+      },
+      {
+        "expression": "hasProperty(\"abc\", \"key\")",
+        "error": "TypeError"
+      },
       {
         "expression": "and(true() true())",
         "error": "SyntaxError"
@@ -137,6 +146,10 @@
         "result": 3
       },
       {
+        "expression": "abs([-1, 3, [-4, 5]])",
+        "result": [1, 3, [4, 5]]
+      },
+      {
         "expression": "abs(`false`)",
         "result": 0
       },
@@ -192,6 +205,10 @@
       {
         "expression": "avg(`[2,1,\"b\"]`)",
         "result": 1.5
+      },
+      {
+        "expression": "avg([1, 2, [3, 4, `[5]`]])",
+        "result": 3
       },
       {
         "expression": "avg(`null`)",
@@ -1506,6 +1523,10 @@
         "result": 1.5707963267948966
       },
       {
+        "expression": "acos([0, [0, 0]])",
+        "result": [1.5707963267948966, [1.5707963267948966, 1.5707963267948966]]
+      },
+      {
         "expression": "acos(1.01)",
         "error": "EvaluationError"
       },
@@ -1957,6 +1978,10 @@
         ]
       },
       {
+        "expression": "asin([1, [0, 0.19866933079506123]])",
+        "result": [1.5707963267948966, [0, 0.2]]
+      },
+      {
         "expression": "atan2(arrayNum, 10)",
         "result": [
           -0.32172055409664824, -0.21845717120535865, -0.10955952677394436, 0,
@@ -1971,327 +1996,782 @@
         ]
       },
       {
-        "expression": "casefold(arrayStr)",
-        "result": ["abc", "bcd", "cde", "def", "efg"]
+        "expression": "atan2(1, [1, [2, 3]])",
+        "result": [0.7853981633974483, [0.4636476090008061, 0.3217505543966422]]
       },
       {
-        "expression": "ceil(arrayNum)",
-        "result": [-3, -2, -1, 0, 2, 3, 4]
+        "expression": "ceil([1.1, [2.2, 3.3]])",
+        "result": [2, [3, 4]]
       },
       {
-        "expression": "codePoint(arrayStr)",
-        "result": [97, 98, 99, 100, 101]
+        "expression": "codePoint([\"A\", [\"B\", \"C\"]])",
+        "result": [65, [66, 67]]
       },
       {
-        "expression": "cos(arrayNum)",
-        "result": [
-          -0.9817374728267503, -0.6045522710579296, 0.4535961214255773, 1,
-          0.4535961214255773, -0.6045522710579296, -0.9817374728267503
-        ]
+        "expression": "cos([1, [2, 3]])",
+        "result": [0.5403023058681398, [-0.4161468365471424, -0.9899924966004454]]
       },
       {
-        "expression": "now() | datedif(@, @ + 1, [\"y\",\"m\",\"d\",\"ym\",\"yd\"])",
-        "result": [0, 0, 1, 0, 1]
+        "expression": "now() | datedif([@, [@, @]], [@ + 1, [@ + 2, @ + 3]], \"d\")",
+        "result": [1, [2, 3]]
       },
       {
-        "expression": "now() | datedif([@, @], [@ + 1, @ + 2], \"d\")",
-        "result": [1, 2]
+        "expression": "datetime(2024, 3, 8) | day([[@, @], [@, @]])",
+        "result": [[8, 8], [8, 8]]
       },
+      {
+        "expression": "endsWith([\"abc\", [\"def\", \"ghi\"]], \"c\")",
+        "result": [true, [false, false]]
+      },
+      {
+        "expression": "datetime(2024, 3, 8) | eomonth([[@, @], [@, @]], 1)",
+        "result": [[19843.166666666668, 19843.166666666668], [19843.166666666668, 19843.166666666668]]
+      },
+      {
+        "expression": "exp([1, [2, 3]])",
+        "result": [2.718281828459045, [7.38905609893065, 20.085536923187668]]
+      },
+      {
+        "expression": "find(\"a\", [\"abc\", [\"def\", \"ghi\"]], [0, [1, 2]])",
+        "result": [0, [null, null]]
+      },
+      {
+        "expression": "floor([1.1, [2.2, 3.3]])",
+        "result": [1, [2, 3]]
+      },
+      {
+        "expression": "fround([1.1, [2.2, 3.3]])",
+        "result": [1.100000023841858, [2.200000047683716, 3.299999952316284]]
+      },
+      {
+        "expression": "datetime(2024, 3, 8, 13, 45) | hour([[@, @], [@, @]])",
+        "result": [[13, 13], [13, 13]]
+      },
+      {
+        "expression": "log([1, [2, 3]])",
+        "result": [0, [0.6931471805599453, 1.0986122886681096]]
+      },
+      {
+        "expression": "log10([1, [2, 3]])",
+        "result": [0, [0.3010299956639812, 0.47712125471966244]]
+      },
+      {
+        "expression": "lower([\"ABC\", [\"DEF\", \"GHI\"]])",
+        "result": ["abc", ["def", "ghi"]]
+      },
+      {
+        "expression": "max([1, [2, 3]])",
+        "result": 3
+      },
+      {
+        "expression": "datetime(2024, 3, 8, 13, 45, 30, 500) | millisecond([[@, @], [@, @]])",
+        "result": [[500, 500], [500, 500]]
+      },
+      {
+        "expression": "min([2, [1, 3]])",
+        "result": 1
+      },
+      {
+        "expression": "datetime(2024, 3, 8, 13, 45) | minute([[@, @], [@, @]])",
+        "result": [[45, 45], [45, 45]]
+      },
+      {
+        "expression": "mod([2, [4, 6]], [1, [2, 3]])",
+        "result": [0, [0, 0]]
+      },
+      {
+        "expression": "datetime(2024, 3, 8) | month([[@, @], [@, @]])",
+        "result": [[3, 3], [3, 3]]
+      },
+      {
+        "expression": "power([2, [3, 4]], [2, [2, 2]])",
+        "result": [4, [9, 16]]
+      },
+      {
+        "expression": "proper([\"abc\", [\"def\", \"ghi\"]])",
+        "result": ["Abc", ["Def", "Ghi"]]
+      },
+      {
+        "expression": "rept([\"a\", [\"b\", \"c\"]], [2, [2, 2]])",
+        "result": ["aa", ["bb", "cc"]]
+      },
+      {
+        "expression": "round([1.5, [2.5, 3.5]])",
+        "result": [2, [3, 4]]
+      },
+      {
+        "expression": "search(\"a\", [\"abc\", [\"def\", \"ghi\"]], [0, [0, 0]])",
+        "result": [[0, "a"], [[], []]]
+      },
+      {
+        "expression": "datetime(2024, 3, 8, 13, 45, 30) | second([[@, @], [@, @]])",
+        "result": [[30, 30], [30, 30]]
+      },
+      {
+        "expression": "sign([1.1, [-2.2, 3.3]])",
+        "result": [1, [-1, 1]]
+      },
+      {
+        "expression": "sin([1, [2, 3]])",
+        "result": [0.8414709848078965, [0.9092974268256817, 0.1411200080598672]]
+      },
+      {
+        "expression": "split([\"a,b\", [\"c,d\", \"e,f\"]], \",\")",
+        "result": [["a", "b"], [["c", "d"], ["e", "f"]]]
+      },
+      {
+        "expression": "sqrt([4, [9, 16]])",
+        "result": [2, [3, 4]]
+      },
+      {
+        "expression": "startsWith([\"abc\", [\"def\", \"ghi\"]], \"a\")",
+        "result": [true, [false, false]]
+      },
+      {
+        "expression": "stdev([1, [2, 3]])",
+        "result": 1
+      },
+      {
+        "expression": "stdevA([1, [2, 3]])",
+        "result": 1
+      },
+      {
+        "expression": "stdevp([1, [2, 3]])",
+        "result": 0.8164965809277263
+      },
+      {
+        "expression": "stdevpA([1, [2, 3]])",
+        "result": 0.8164965809277263
+      },
+      {
+        "expression": "substitute([\"abc\", [\"aab\", \"ghi\"]], \"a\", \"A\", [0, [1, 0]])",
+        "result": ["Abc", ["aAb", "ghi"]]
+      },
+      {
+        "expression": "sum([1, [2, 3]])",
+        "result": 6
+      },
+      {
+        "expression": "tan([1, [2, 3]])",
+        "result": [1.5574077246549023, [-2.185039863261519, -0.1425465430742778]]
+      },
+      {
+        "expression": "trim([\" abc \", [\" def \", \" ghi \"]])",
+        "result": ["abc", ["def", "ghi"]]
+      },
+      {
+        "expression": "trunc([1.5, [2.5, 3.5]])",
+        "result": [1, [2, 3]]
+      },
+      {
+        "expression": "upper([\"abc\", [\"def\", \"ghi\"]])",
+        "result": ["ABC", ["DEF", "GHI"]]
+      },
+      {
+        "expression": "datetime(2024, 3, 8) | weekday([[@, @], [@, @]], 1)",
+        "result": [[6, 6], [6, 6]]
+      },
+      {
+        "expression": "datetime(2024, 3, 8) | year([[@, @], [@, @]])",
+        "result": [[2024, 2024], [2024, 2024]]
+      },
+      {
+          "expression": "abs([-1, 3, [-4, 5]])",
+         "result": [1, 3, [4, 5]]
+       },
+       {
+         "expression": "avg([1, 2, [3, 4, `[5]`]])",
+         "result": 3
+       },
+       {
+         "expression": "acos([0, [0, 0]])",
+         "result": [1.5707963267948966, [1.5707963267948966, 1.5707963267948966]]
+       },
+       {
+         "expression": "asin([1, [0, 0.19866933079506123]])",
+         "result": [1.5707963267948966, [0, 0.2]]
+        },
+        {
 
+         "expression": "atan2(1, [1, [2, 3]])",
+         "result": [0.7853981633974483, [0.4636476090008061, 0.3217505543966422]]
+        },
+        {
 
+         "expression": "casefold(arrayStr)",
+         "result": ["abc", "bcd", "cde", "def", "efg"]
+        },
+        {
+         "expression": "ceil([1.1, [2.2, 3.3]])",
+         "result": [2, [3, 4]]
+        },
+        {
+          "expression": "ceil(arrayNum)",
+         "result": [-3, -2, -1, 0, 2, 3, 4]
+        },
+        {
 
-      {
-        "expression": "datetime(2024, 10, 12) | day([@, @ + 1])",
-        "result": [12, 13]
-      },
-      {
-        "expression": "endsWith(arrayStr, arrayStr)",
-        "result": [true, true, true, true, true]
-      },
-      {
-        "expression": "endsWith(arrayStr, \"c\")",
-        "result": [true, false, false, false, false]
-      },
-      {
-        "expression": "datetime(2024, 10, 12) | eomonth([@, @, @, @, @, @, @], 1)| [month(@) & day(@)][]",
-        "result": ["1130", "1130", "1130", "1130", "1130", "1130", "1130"]
-      },
-      {
-        "expression": "{d: datetime(2024, 10, 12), n:arrayInt} | eomonth([@.d, @.d, @.d, @.d, @.d, @.d, @.d], @.n) | [month(@) & day(@)][]",
-        "result": ["1130", "1231", "131", "228", "331", "430", "531"]
-      },
-      {
-        "expression": "exp(arrayInt)",
-        "result": [
-          2.718281828459045, 7.38905609893065, 20.085536923187668,
-          54.598150033144236, 148.4131591025766, 403.4287934927351,
-          1096.6331584284585
-        ]
-      },
-      {
-        "expression": "find(arrayStr, arrayStr, [0,0,0,0,0,0])",
-        "result": [0, 0, 0, 0, 0, 0]
-      },
-      {
-        "expression": "find(\"c\", [\"cc\",\"ccc\",\"cccc\",\"ccccc\",\"cccccc\",\"ccccccc\",\"cccccccc\"], arrayInt)",
-        "result": [1, 2, 3, 4, 5, 6, 7]
-      },
-      {
-        "expression": "find(arrayStr, arrayStr, 0)",
-        "result": [0, 0, 0, 0, 0]
-      },
-      {
-        "expression": "find(\"c\", \"abcdefg\", arrayInt)",
-        "result": [2, 2, null, null, null, null, null]
-      },
-      {
-        "expression": "floor(arrayNum)",
-        "result": [-4, -3, -2, 0, 1, 2, 3]
-      },
-      {
-        "expression": "fromCodePoint(64 + arrayInt)",
-        "result": "ABCDEFG"
-      },
-      {
-        "expression": "fround(arrayNum)",
-        "result": [
-          -3.3329999446868896, -2.2200000286102295, -1.100000023841858, 0,
-          1.100000023841858, 2.2200000286102295, 3.3329999446868896
-        ]
-      },
-      {
-        "expression": "datetime(2024, 10, 12, 13) | hour([@, @])",
-        "result": [13, 13]
-      },
-      {
-        "expression": "log(arrayInt)",
-        "result": [
-          0, 0.6931471805599453, 1.0986122886681096, 1.3862943611198906,
-          1.6094379124341003, 1.791759469228055, 1.9459101490553132
-        ]
-      },
-      {
-        "expression": "log10(arrayInt)",
-        "result": [
-          0, 0.3010299956639812, 0.47712125471966244, 0.6020599913279624,
-          0.6989700043360189, 0.7781512503836436, 0.8450980400142568
-        ]
-      },
-      {
-        "expression": "lower(arrayStr)",
-        "result": ["abc", "bcd", "cde", "def", "efg"]
-      },
-      {
-        "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | millisecond([@, @ + 1])",
-        "result": [16, 16]
-      },
-      {
-        "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | minute([@, @ + 1])",
-        "result": [14, 14]
-      },
-      {
-        "expression": "mod(arrayInt, 2)",
-        "result": [1, 0, 1, 0, 1, 0, 1]
-      },
-      {
-        "expression": "mod(arrayInt, arrayInt + 1)",
-        "result": [1, 2, 3, 4, 5, 6, 7]
-      },
-      {
-        "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | month([@, @])",
-        "result": [10, 10]
-      },
-      {
-        "expression": "power(arrayInt, arrayInt)",
-        "result": [1, 4, 27, 256, 3125, 46656, 823543]
-      },
-      {
-        "expression": "power(arrayInt, 2)",
-        "result": [1, 4, 9, 16, 25, 36, 49]
-      },
-      {
-        "expression": "power(2, arrayInt)",
-        "result": [2, 4, 8, 16, 32, 64, 128]
-      },
-      {
-        "expression": "proper(arrayStr)",
-        "result": ["Abc", "Bcd", "Cde", "Def", "Efg"]
-      },
-      {
-        "expression": "rept(arrayStr, arrayInt)",
-        "result": [
-          "abc",
-          "bcdbcd",
-          "cdecdecde",
-          "defdefdefdef",
-          "efgefgefgefgefg",
-          "",
-          ""
-        ]
-      },
-      {
-        "expression": "rept(arrayStr, 2)",
-        "result": ["abcabc", "bcdbcd", "cdecde", "defdef", "efgefg"]
-      },
-      {
-        "expression": "rept(\"a\", arrayInt)",
-        "result": ["a", "aa", "aaa", "aaaa", "aaaaa", "aaaaaa", "aaaaaaa"]
-      },
-      {
-        "expression": "round(arrayNum)",
-        "result": [-3, -2, -1, 0, 1, 2, 3]
-      },
-      {
-        "expression": "search(arrayStr, arrayStr, [0,0,0,0,0])",
-        "result": [
-          [0, "abc"],
-          [0, "bcd"],
-          [0, "cde"],
-          [0, "def"],
-          [0, "efg"]
-        ]
-      },
-      {
-        "expression": "search(\"c\", arrayStr, [0,1,2,3,4,5])",
-        "result": [[2, "c"], [1, "c"], [], [], [], []]
-      },
-      {
-        "expression": "search(arrayStr, arrayStr, 0)",
-        "result": [
-          [0, "abc"],
-          [0, "bcd"],
-          [0, "cde"],
-          [0, "def"],
-          [0, "efg"]
-        ]
-      },
-      {
-        "expression": "search(arrayStr, \"abcdefg\", [0,1,2,3])",
-        "result": [
-          [0, "abc"],
-          [1, "bcd"],
-          [2, "cde"],
-          [3, "def"],
-          [4, "efg"]
-        ]
-      },
-      {
-        "expression": "search(\"b\", \"abcbebg\", [0,1,2,3])",
-        "result": [
-          [1, "b"],
-          [1, "b"],
-          [3, "b"],
-          [3, "b"]
-        ]
-      },
-      {
-        "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | second([@, @])",
-        "result": [15, 15]
-      },
-      {
-        "expression": "sign(arrayInt)",
-        "result": [1, 1, 1, 1, 1, 1, 1]
-      },
-      {
-        "expression": "sin(arrayNum)",
-        "result": [
-          0.19024072762619915, -0.7965654722360865, -0.8912073600614354, 0,
-          0.8912073600614354, 0.7965654722360865, -0.19024072762619915
-        ]
-      },
-      {
-        "expression": "split(arrayStr, \"\")",
-        "result": [
-          ["a", "b", "c"],
-          ["b", "c", "d"],
-          ["c", "d", "e"],
-          ["d", "e", "f"],
-          ["e", "f", "g"]
-        ]
-      },
-      {
-        "expression": "split(\"abcdefg\", [\"b\", \"c\"])",
-        "result": [
-          ["a", "cdefg"],
-          ["ab", "defg"]
-        ]
-      },
-      {
-        "expression": "split(arrayStr, [\"a\", \"b\"])",
-        "result": [
-          ["", "bc"],
-          ["", "cd"],
-          ["c", "d", "e"],
-          ["d", "e", "f"],
-          ["e", "f", "g"]
-        ]
-      },
-      {
-        "expression": "sqrt(arrayNum[?@ > 0])",
-        "result": [
-          1.0488088481701516,
-          1.489966442575134,
-          1.8256505689753448
-        ]
-      },
-      {
-        "expression": "startsWith(arrayStr, arrayStr)",
-        "result": [true,
-        true,
-        true,
-        true,
-        true]
-      },
-      {
-        "expression": "startsWith(arrayStr, \"b\")",
-        "result": [
-          false,
-          true,
-          false,
-          false,
-          false
-        ]
-      },
-      {
-        "expression": "startsWith(\"abcdefg\", [\"a\", \"b\", \"c\"])",
-        "result": [
-          true,
-          false,
-          false
-        ]
-      },
-      {
-        "expression": "substitute(arrayStr, \"c\", \"C\", [0,0,0,0,0])",
-        "result": ["abC","bCd","Cde","def","efg"]
-      },
-      {
-        "expression": "tan(arrayNum)",
-        "result": [-0.1937796334476594, 1.3176122402817965, -1.9647596572486523, 0, 1.9647596572486523, -1.3176122402817965, 0.1937796334476594]
-      },
-      {
-        "expression": "trim(arrayStr)",
-        "result": ["abc", "bcd", "cde", "def", "efg"]
-      },
-      {
-        "expression": "trunc(arrayNum, [1,1,0,0,0,1,1])",
-        "result": [-3.3, -2.2, -1, 0, 1, 2.2, 3.3]
-      },
-      {
-        "expression": "trunc(arrayNum)",
-        "result": [-3, -2, -1, 0, 1, 2, 3]
-      },
-      {
-        "expression": "upper(arrayStr)",
-        "result": ["ABC", "BCD", "CDE", "DEF", "EFG"]
-      },
-      {
-        "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | weekday([@, @ + 1], 1)",
-        "result": [7, 1]
-      },
-      {
-        "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | year([@, @ + 1])",
-        "result": [2024, 2024]
-      }
+         "expression": "codePoint([\"A\", [\"B\", \"C\"]])",
+         "result": [65, [66, 67]]
+        },
+        {
+
+         "expression": "codePoint(arrayStr)",
+         "result": [97, 98, 99, 100, 101]
+        },
+        {
+
+         "expression": "cos([1, [2, 3]])",
+         "result": [0.5403023058681398, [-0.4161468365471424, -0.9899924966004454]]
+        },
+        {
+
+         "expression": "cos(arrayNum)",
+         "result": [
+           -0.9817374728267503, -0.6045522710579296, 0.4535961214255773, 1,
+           0.4535961214255773, -0.6045522710579296, -0.9817374728267503
+         ]
+        },
+        {
+
+         "expression": "now() | datedif([@, [@, @]], [@ + 1, [@ + 2, @ + 3]], \"d\")",
+         "result": [1, [2, 3]]
+        },
+        {
+
+         "expression": "now() | datedif(@, @ + 1, [\"y\",\"m\",\"d\",\"ym\",\"yd\"])",
+         "result": [0, 0, 1, 0, 1]
+        },
+        {
+
+         "expression": "datetime(2024, 3, 8) | day([[@, @], [@, @]])",
+         "result": [[8, 8], [8, 8]]
+        },
+        {
+
+         "expression": "now() | datedif([@, @], [@ + 1, @ + 2], \"d\")",
+         "result": [1, 2]
+        },
+        {
+         "expression": "endsWith([\"abc\", [\"def\", \"ghi\"]], \"c\")",
+         "result": [true, [false, false]]
+        },
+        {
+          "expression": "datetime(2024, 10, 12) | day([@, @ + 1])",
+         "result": [12, 13]
+        },
+        {
+
+         "expression": "datetime(2024, 3, 8) | eomonth([[@, @], [@, @]], 1)",
+         "result": [[19843.166666666668, 19843.166666666668], [19843.166666666668, 19843.166666666668]]
+        },
+        {
+
+         "expression": "endsWith(arrayStr, arrayStr)",
+         "result": [true, true, true, true, true]
+        },
+        {
+
+         "expression": "exp([1, [2, 3]])",
+         "result": [2.718281828459045, [7.38905609893065, 20.085536923187668]]
+        },
+        {
+
+         "expression": "endsWith(arrayStr, \"c\")",
+         "result": [true, false, false, false, false]
+        },
+        {
+
+         "expression": "find(\"a\", [\"abc\", [\"def\", \"ghi\"]], [0, [1, 2]])",
+         "result": [0, [null, null]]
+        },
+        {
+
+         "expression": "datetime(2024, 10, 12) | eomonth([@, @, @, @, @, @, @], 1)| [month(@) & day(@)][]",
+         "result": ["1130", "1130", "1130", "1130", "1130", "1130", "1130"]
+        },
+        {
+
+         "expression": "floor([1.1, [2.2, 3.3]])",
+         "result": [1, [2, 3]]
+       },
+       {
+
+         "expression": "{d: datetime(2024, 10, 12), n:arrayInt} | eomonth([@.d, @.d, @.d, @.d, @.d, @.d, @.d], @.n) | [month(@) & day(@)][]",
+         "result": ["1130", "1231", "131", "228", "331", "430", "531"]
+        },
+        {
+
+         "expression": "fround([1.1, [2.2, 3.3]])",
+         "result": [1.100000023841858, [2.200000047683716, 3.299999952316284]]
+        },
+        {
+
+         "expression": "exp(arrayInt)",
+         "result": [
+           2.718281828459045, 7.38905609893065, 20.085536923187668,
+           54.598150033144236, 148.4131591025766, 403.4287934927351,
+           1096.6331584284585
+         ]
+        },
+        {
+
+         "expression": "datetime(2024, 3, 8, 13, 45) | hour([[@, @], [@, @]])",
+         "result": [[13, 13], [13, 13]]
+        },
+        {
+
+         "expression": "find(arrayStr, arrayStr, [0,0,0,0,0,0])",
+         "result": [0, 0, 0, 0, 0, 0]
+        },
+        {
+
+         "expression": "log([1, [2, 3]])",
+         "result": [0, [0.6931471805599453, 1.0986122886681096]]
+        },
+        {
+
+         "expression": "find(\"c\", [\"cc\",\"ccc\",\"cccc\",\"ccccc\",\"cccccc\",\"ccccccc\",\"cccccccc\"], arrayInt)",
+         "result": [1, 2, 3, 4, 5, 6, 7]
+        },
+        {
+
+         "expression": "log10([1, [2, 3]])",
+         "result": [0, [0.3010299956639812, 0.47712125471966244]]
+        },
+        {
+
+         "expression": "find(arrayStr, arrayStr, 0)",
+         "result": [0, 0, 0, 0, 0]
+        },
+        {
+
+         "expression": "lower([\"ABC\", [\"DEF\", \"GHI\"]])",
+         "result": ["abc", ["def", "ghi"]]
+        },
+        {
+
+         "expression": "find(\"c\", \"abcdefg\", arrayInt)",
+         "result": [2, 2, null, null, null, null, null]
+        },
+        {
+         "expression": "max([1, [2, 3]])",
+         "result": 3
+        },
+        {
+         "expression": "floor(arrayNum)",
+         "result": [-4, -3, -2, 0, 1, 2, 3]
+        },
+        {
+         "expression": "datetime(2024, 3, 8, 13, 45, 30, 500) | millisecond([[@, @], [@, @]])",
+         "result": [[500, 500], [500, 500]]
+        },
+        {
+         "expression": "fromCodePoint(64 + arrayInt)",
+         "result": "ABCDEFG"
+        },
+        {
+
+         "expression": "min([2, [1, 3]])",
+         "result": 1
+        },
+        {
+
+         "expression": "fround(arrayNum)",
+         "result": [
+           -3.3329999446868896, -2.2200000286102295, -1.100000023841858, 0,
+           1.100000023841858, 2.2200000286102295, 3.3329999446868896
+         ]
+        },
+        {
+
+         "expression": "datetime(2024, 3, 8, 13, 45) | minute([[@, @], [@, @]])",
+         "result": [[45, 45], [45, 45]]
+        },
+        {
+
+         "expression": "datetime(2024, 10, 12, 13) | hour([@, @])",
+         "result": [13, 13]
+        },
+        {
+
+         "expression": "mod([2, [4, 6]], [1, [2, 3]])",
+         "result": [0, [0, 0]]
+        },
+        {
+
+         "expression": "log(arrayInt)",
+         "result": [
+           0, 0.6931471805599453, 1.0986122886681096, 1.3862943611198906,
+           1.6094379124341003, 1.791759469228055, 1.9459101490553132
+         ]
+        },
+        {
+
+         "expression": "datetime(2024, 3, 8) | month([[@, @], [@, @]])",
+         "result": [[3, 3], [3, 3]]
+        },
+        {
+
+         "expression": "log10(arrayInt)",
+         "result": [
+           0, 0.3010299956639812, 0.47712125471966244, 0.6020599913279624,
+           0.6989700043360189, 0.7781512503836436, 0.8450980400142568
+         ]
+        },
+        {
+
+         "expression": "power([2, [3, 4]], [2, [2, 2]])",
+         "result": [4, [9, 16]]
+        },
+        {
+
+         "expression": "lower(arrayStr)",
+         "result": ["abc", "bcd", "cde", "def", "efg"]
+        },
+        {
+
+         "expression": "proper([\"abc\", [\"def\", \"ghi\"]])",
+         "result": ["Abc", ["Def", "Ghi"]]
+        },
+        {
+
+         "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | millisecond([@, @ + 1])",
+         "result": [16, 16]
+        },
+        {
+
+         "expression": "rept([\"a\", [\"b\", \"c\"]], [2, [2, 2]])",
+         "result": ["aa", ["bb", "cc"]]
+        },
+        {
+
+         "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | minute([@, @ + 1])",
+         "result": [14, 14]
+        },
+        {
+
+         "expression": "round([1.5, [2.5, 3.5]])",
+         "result": [2, [3, 4]]
+        },
+        {
+
+         "expression": "mod(arrayInt, 2)",
+         "result": [1, 0, 1, 0, 1, 0, 1]
+        },
+        {
+
+         "expression": "search(\"a\", [\"abc\", [\"def\", \"ghi\"]], [0, [0, 0]])",
+         "result": [[0, "a"], [[], []]]
+        },
+        {
+
+         "expression": "mod(arrayInt, arrayInt + 1)",
+         "result": [1, 2, 3, 4, 5, 6, 7]
+        },
+        {
+
+         "expression": "datetime(2024, 3, 8, 13, 45, 30) | second([[@, @], [@, @]])",
+         "result": [[30, 30], [30, 30]]
+        },
+        {
+
+         "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | month([@, @])",
+         "result": [10, 10]
+        },
+        {
+
+         "expression": "sign([1.1, [-2.2, 3.3]])",
+         "result": [1, [-1, 1]]
+        },
+        {
+
+         "expression": "power(arrayInt, arrayInt)",
+         "result": [1, 4, 27, 256, 3125, 46656, 823543]
+        },
+        {
+
+         "expression": "sin([1, [2, 3]])",
+         "result": [0.8414709848078965, [0.9092974268256817, 0.1411200080598672]]
+        },
+        {
+
+         "expression": "power(arrayInt, 2)",
+         "result": [1, 4, 9, 16, 25, 36, 49]
+        },
+        {
+
+         "expression": "split([\"a,b\", [\"c,d\", \"e,f\"]], \",\")",
+         "result": [["a", "b"], [["c", "d"], ["e", "f"]]]
+        },
+        {
+
+         "expression": "power(2, arrayInt)",
+         "result": [2, 4, 8, 16, 32, 64, 128]
+        },
+        {
+
+         "expression": "sqrt([4, [9, 16]])",
+         "result": [2, [3, 4]]
+        },
+        {
+
+         "expression": "proper(arrayStr)",
+         "result": ["Abc", "Bcd", "Cde", "Def", "Efg"]
+        },
+        {
+
+         "expression": "startsWith([\"abc\", [\"def\", \"ghi\"]], \"a\")",
+         "result": [true, [false, false]]
+        },
+        {
+
+         "expression": "rept(arrayStr, arrayInt)",
+         "result": [
+           "abc",
+           "bcdbcd",
+           "cdecdecde",
+           "defdefdefdef",
+           "efgefgefgefgefg",
+           "",
+           ""
+         ]
+        },
+        {
+
+         "expression": "stdev([1, [2, 3]])",
+         "result": 1
+        },
+        {
+
+         "expression": "rept(arrayStr, 2)",
+         "result": ["abcabc", "bcdbcd", "cdecde", "defdef", "efgefg"]
+        },
+        {
+
+         "expression": "stdevA([1, [2, 3]])",
+         "result": 1
+        },
+        {
+
+         "expression": "rept(\"a\", arrayInt)",
+         "result": ["a", "aa", "aaa", "aaaa", "aaaaa", "aaaaaa", "aaaaaaa"]
+        },
+        {
+
+         "expression": "stdevp([1, [2, 3]])",
+         "result": 0.8164965809277263
+        },
+        {
+
+         "expression": "round(arrayNum)",
+         "result": [-3, -2, -1, 0, 1, 2, 3]
+        },
+        {
+
+         "expression": "stdevpA([1, [2, 3]])",
+         "result": 0.8164965809277263
+        },
+        {
+
+         "expression": "search(arrayStr, arrayStr, [0,0,0,0,0])",
+         "result": [
+           [0, "abc"],
+           [0, "bcd"],
+           [0, "cde"],
+           [0, "def"],
+           [0, "efg"]
+         ]
+        },
+        {
+
+         "expression": "substitute([\"abc\", [\"aab\", \"ghi\"]], \"a\", \"A\", [0, [1, 0]])",
+         "result": ["Abc", ["aAb", "ghi"]]
+        },
+        {
+
+         "expression": "search(\"c\", arrayStr, [0,1,2,3,4,5])",
+         "result": [[2, "c"], [1, "c"], [], [], [], []]
+        },
+        {
+
+         "expression": "sum([1, [2, 3]])",
+         "result": 6
+        },
+        {
+
+         "expression": "search(arrayStr, arrayStr, 0)",
+         "result": [
+           [0, "abc"],
+           [0, "bcd"],
+           [0, "cde"],
+           [0, "def"],
+           [0, "efg"]
+         ]
+        },
+        {
+
+         "expression": "tan([1, [2, 3]])",
+         "result": [1.5574077246549023, [-2.185039863261519, -0.1425465430742778]]
+        },
+        {
+
+         "expression": "search(arrayStr, \"abcdefg\", [0,1,2,3])",
+         "result": [
+           [0, "abc"],
+           [1, "bcd"],
+           [2, "cde"],
+           [3, "def"],
+           [4, "efg"]
+         ]
+        },
+        {
+
+         "expression": "trim([\" abc \", [\" def \", \" ghi \"]])",
+         "result": ["abc", ["def", "ghi"]]
+        },
+        {
+
+         "expression": "search(\"b\", \"abcbebg\", [0,1,2,3])",
+         "result": [
+           [1, "b"],
+           [1, "b"],
+           [3, "b"],
+           [3, "b"]
+         ]
+        },
+        {
+
+         "expression": "trunc([1.5, [2.5, 3.5]])",
+         "result": [1, [2, 3]]
+        },
+        {
+
+         "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | second([@, @])",
+         "result": [15, 15]
+        },
+        {
+
+         "expression": "upper([\"abc\", [\"def\", \"ghi\"]])",
+         "result": ["ABC", ["DEF", "GHI"]]
+        },
+        {
+
+         "expression": "sign(arrayInt)",
+         "result": [1, 1, 1, 1, 1, 1, 1]
+        },
+        {
+
+         "expression": "datetime(2024, 3, 8) | weekday([[@, @], [@, @]], 1)",
+         "result": [[6, 6], [6, 6]]
+        },
+        {
+
+         "expression": "sin(arrayNum)",
+         "result": [
+           0.19024072762619915, -0.7965654722360865, -0.8912073600614354, 0,
+           0.8912073600614354, 0.7965654722360865, -0.19024072762619915
+         ]
+        },
+        {
+
+         "expression": "datetime(2024, 3, 8) | year([[@, @], [@, @]])",
+         "result": [[2024, 2024], [2024, 2024]]
+        },
+        {
+
+         "expression": "split(arrayStr, \"\")",
+         "result": [
+           ["a", "b", "c"],
+           ["b", "c", "d"],
+           ["c", "d", "e"],
+           ["d", "e", "f"],
+           ["e", "f", "g"]
+         ]
+       },
+       {
+         "expression": "split(\"abcdefg\", [\"b\", \"c\"])",
+         "result": [
+           ["a", "cdefg"],
+           ["ab", "defg"]
+         ]
+       },
+       {
+         "expression": "split(arrayStr, [\"a\", \"b\"])",
+         "result": [
+           ["", "bc"],
+           ["", "cd"],
+           ["c", "d", "e"],
+           ["d", "e", "f"],
+           ["e", "f", "g"]
+         ]
+       },
+       {
+         "expression": "sqrt(arrayNum[?@ > 0])",
+         "result": [
+           1.0488088481701516,
+           1.489966442575134,
+           1.8256505689753448
+         ]
+       },
+       {
+         "expression": "startsWith(arrayStr, arrayStr)",
+         "result": [true,
+         true,
+         true,
+         true,
+         true]
+       },
+       {
+         "expression": "startsWith(arrayStr, \"b\")",
+         "result": [
+           false,
+           true,
+           false,
+           false,
+           false
+         ]
+       },
+       {
+         "expression": "startsWith(\"abcdefg\", [\"a\", \"b\", \"c\"])",
+         "result": [
+           true,
+           false,
+           false
+         ]
+       },
+       {
+         "expression": "substitute(arrayStr, \"c\", \"C\", [0,0,0,0,0])",
+         "result": ["abC","bCd","Cde","def","efg"]
+       },
+       {
+         "expression": "tan(arrayNum)",
+         "result": [-0.1937796334476594, 1.3176122402817965, -1.9647596572486523, 0, 1.9647596572486523, -1.3176122402817965, 0.1937796334476594]
+       },
+       {
+         "expression": "trim(arrayStr)",
+         "result": ["abc", "bcd", "cde", "def", "efg"]
+       },
+       {
+         "expression": "trunc(arrayNum, [1,1,0,0,0,1,1])",
+         "result": [-3.3, -2.2, -1, 0, 1, 2.2, 3.3]
+       },
+       {
+         "expression": "trunc(arrayNum)",
+         "result": [-3, -2, -1, 0, 1, 2, 3]
+       },
+       {
+         "expression": "upper(arrayStr)",
+         "result": ["ABC", "BCD", "CDE", "DEF", "EFG"]
+       },
+       {
+         "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | weekday([@, @ + 1], 1)",
+         "result": [7, 1]
+       },
+       {
+         "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | year([@, @ + 1])",
+         "result": [2024, 2024]
+       }
     ]
   }
 ]

--- a/test/functions.json
+++ b/test/functions.json
@@ -166,7 +166,7 @@
       },
       {
         "expression": "avg(array)",
-        "error": "TypeError"
+        "result": 2.75
       },
       {
         "expression": "avg('abc')",
@@ -183,7 +183,7 @@
       },
       {
         "expression": "avg(strings)",
-        "error": "TypeError"
+        "error": "EvaluationError"
       },
       {
         "expression": "avg(`[]`)",
@@ -191,11 +191,52 @@
       },
       {
         "expression": "avg(`[2,1,\"b\"]`)",
-        "error": "TypeError"
+        "result": 1.5
       },
       {
         "expression": "avg(`null`)",
         "error": "TypeError"
+      },
+      {
+        "expression": "avgA(numbers)",
+        "result": 2.75
+      },
+      {
+        "expression": "avgA(array)",
+        "error": "TypeError"
+      },
+      {
+        "expression": "avgA('abc')",
+        "error": "TypeError"
+      },
+      {
+        "expression": "avgA(foo)",
+        "result": -1,
+        "was": "TypeError"
+      },
+      {
+        "expression": "avgA(@)",
+        "error": "TypeError"
+      },
+      {
+        "expression": "avgA(strings)",
+        "error": "TypeError"
+      },
+      {
+        "expression": "avgA(`[]`)",
+        "error": "EvaluationError"
+      },
+      {
+        "expression": "avgA(`[2,1,\"b\"]`)",
+        "error": "TypeError"
+      },
+      {
+        "expression": "avgA(`null`)",
+        "error": "TypeError"
+      },
+      {
+        "expression": "avgA([1,[2,[3,[4,5]],6]])",
+        "result": 3.5
       },
       {
         "expression": "ceil(`1.2`)",
@@ -423,15 +464,15 @@
       },
       {
         "expression": "max(strings)",
-        "result": "c"
+        "result": 0
       },
       {
         "expression": "max(abc)",
-        "error": "TypeError"
+        "result": 0
       },
       {
         "expression": "max(array)",
-        "error": "TypeError"
+        "result": 5
       },
       {
         "expression": "max(decimals)",
@@ -439,19 +480,19 @@
       },
       {
         "expression": "max(empty_list)",
-        "error": "EvaluationError"
+        "result": 0
       },
       {
         "expression": "max(strings, [\"A\", \"B\", \"C\"])",
-        "result": "c"
+        "result": 0
       },
       {
         "expression": "max([\"D\", \"E\", \"F\"], [\"A\", \"B\", \"C\"])",
-        "result": "F"
+        "result": 0
       },
       {
         "expression": "max(empty_list, \"a\")",
-        "result": "a"
+        "result": 0
       },
       {
         "expression": "max(empty_list, decimals, 0)",
@@ -467,23 +508,79 @@
       },
       {
         "expression": "max([-4, \"foo\"])",
-        "error": "TypeError"
+        "result": -4
       },
       {
         "expression": "max([null(), null()])",
-        "error": "TypeError"
+        "result": 0
       },
       {
         "expression": "max(2,\"3\")",
-        "error": "TypeError"
+        "result": 2
       },
       {
         "expression": "max([2,[4,5]])",
+        "result": 5
+      },
+      {
+        "expression": "maxA(numbers)",
+        "result": 5
+      },
+      {
+        "expression": "maxA(decimals)",
+        "result": 1.2
+      },
+      {
+        "expression": "maxA(strings)",
         "error": "TypeError"
       },
       {
-        "expression": "min(2,\"3\")",
+        "expression": "maxA(abc)",
+        "result": 0
+      },
+      {
+        "expression": "maxA(array)",
         "error": "TypeError"
+      },
+      {
+        "expression": "maxA(decimals)",
+        "result": 1.2
+      },
+      {
+        "expression": "maxA(empty_list)",
+        "result": 0
+      },
+      {
+        "expression": "maxA(strings, [\"A\", \"B\", \"C\"])",
+        "error": "TypeError"
+      },
+      {
+        "expression": "maxA(empty_list, decimals, 0)",
+        "result": 1.2
+      },
+      {
+        "expression": "maxA([1, toNumber(\"2\")])",
+        "result": 2
+      },
+      {
+        "expression": "maxA([-4, \"foo\"])",
+        "error": "TypeError"
+      },
+      {
+        "expression": "maxA([null(), null()])",
+        "result": 0
+      },
+      {
+        "expression": "maxA(2,\"3\")",
+        "result": 3
+      },
+      {
+        "expression": "maxA([2,[4,5]])",
+        "result": 5
+      },
+      {
+        "expression": "min(2,\"3\")",
+        "result": 2
       },
       {
         "expression": "merge(`{}`)",
@@ -523,19 +620,19 @@
       },
       {
         "expression": "min(abc)",
-        "error": "TypeError"
+        "result": 0
       },
       {
         "expression": "min(array)",
-        "error": "TypeError"
+        "result": -1
       },
       {
         "expression": "min(empty_list)",
-        "error": "EvaluationError"
+        "result": 0
       },
       {
         "expression": "min([4, \"foo\"])",
-        "error": "TypeError"
+        "result": 4
       },
       {
         "expression": "min(decimals)",
@@ -543,19 +640,19 @@
       },
       {
         "expression": "min(strings)",
-        "result": "a"
+        "result": 0
       },
       {
         "expression": "min(strings, [\"A\", \"B\", \"C\"])",
-        "result": "A"
+        "result": 0
       },
       {
         "expression": "min([\"D\", \"E\", \"F\"], [\"A\", \"B\", \"C\"])",
-        "result": "A"
+        "result": 0
       },
       {
         "expression": "min(empty_list, \"a\")",
-        "result": "a"
+        "result": 0
       },
       {
         "expression": "min(empty_list, decimals, 0)",
@@ -567,11 +664,63 @@
       },
       {
         "expression": "min(`null`, 23, \"21\")",
-        "error": "TypeError"
+        "result": 23
       },
       {
         "expression": "min([null(), null()])",
+        "result": 0
+      },
+      {
+        "expression": "minA(numbers)",
+        "result": -1
+      },
+      {
+        "expression": "minA(decimals)",
+        "result": -1.5
+      },
+      {
+        "expression": "minA(abc)",
+        "result": 0
+      },
+      {
+        "expression": "minA(array)",
         "error": "TypeError"
+      },
+      {
+        "expression": "minA(empty_list)",
+        "result": 0
+      },
+      {
+        "expression": "minA([4, \"foo\"])",
+        "error": "TypeError"
+      },
+      {
+        "expression": "minA(decimals)",
+        "result": -1.5
+      },
+      {
+        "expression": "minA(strings)",
+        "error": "TypeError"
+      },
+      {
+        "expression": "minA(strings, [\"A\", \"B\", \"C\"])",
+        "error": "TypeError"
+      },
+      {
+        "expression": "minA(empty_list, decimals, 0)",
+        "result": -1.5
+      },
+      {
+        "expression": "minA(empty_list, decimals, 0, [-2, 0])",
+        "result": -2
+      },
+      {
+        "expression": "minA(`null`, 23, \"21\")",
+        "result": 21
+      },
+      {
+        "expression": "minA([null(), null()])",
+        "result": 0
       },
       {
         "expression": "type(\"abc\")",
@@ -612,6 +761,14 @@
       {
         "expression": "sort(keys(objects))",
         "result": ["bar", "foo"]
+      },
+      {
+        "expression": "sort([1,2,[3,4]])",
+        "error": "EvaluationError"
+      },
+      {
+        "expression": "sort([1,2,{a:[3,4]}])",
+        "error": "EvaluationError"
       },
       {
         "expression": "keys(foo)",
@@ -1025,7 +1182,7 @@
       },
       {
         "expression": "sort(array)",
-        "error": "TypeError"
+        "result": [-1, 3, 4, 5, "100", "a"]
       },
       {
         "expression": "sort(abc)",
@@ -1441,6 +1598,10 @@
         "error": "TypeError"
       },
       {
+        "expression": "avgA(&[1,1])",
+        "error": "TypeError"
+      },
+      {
         "expression": "casefold(&\"abc\")",
         "error": "TypeError"
       },
@@ -1557,6 +1718,10 @@
         "error": "TypeError"
       },
       {
+        "expression": "maxA(&[1,2,3])",
+        "error": "TypeError"
+      },
+      {
         "expression": "merge(&{a: 1}, {b: 2})",
         "error": "TypeError"
       },
@@ -1570,6 +1735,10 @@
       },
       {
         "expression": "min(&[1,2,3])",
+        "error": "TypeError"
+      },
+      {
+        "expression": "minA(&[1,2,3])",
         "error": "TypeError"
       },
       {
@@ -1674,6 +1843,14 @@
       },
       {
         "expression": "stdevp(&[1,1])",
+        "error": "TypeError"
+      },
+      {
+        "expression": "stdevA(&[1,1])",
+        "error": "TypeError"
+      },
+      {
+        "expression": "stdevpA(&[1,1])",
         "error": "TypeError"
       },
       {

--- a/test/functions.json
+++ b/test/functions.json
@@ -130,16 +130,8 @@
         "result": 1
       },
       {
-        "expression": "abs(foo)",
-        "result": 1
-      },
-      {
         "expression": "abs(str)",
         "error": "TypeError"
-      },
-      {
-        "expression": "abs(array[1])",
-        "result": 3
       },
       {
         "expression": "abs(array[1])",
@@ -152,10 +144,6 @@
       {
         "expression": "abs(`false`)",
         "result": 0
-      },
-      {
-        "expression": "abs(`-24`)",
-        "result": 24
       },
       {
         "expression": "abs(`-24`)",
@@ -560,10 +548,6 @@
         "error": "TypeError"
       },
       {
-        "expression": "maxA(decimals)",
-        "result": 1.2
-      },
-      {
         "expression": "maxA(empty_list)",
         "result": 0
       },
@@ -650,10 +634,6 @@
       {
         "expression": "min([4, \"foo\"])",
         "result": 4
-      },
-      {
-        "expression": "min(decimals)",
-        "result": -1.5
       },
       {
         "expression": "min(strings)",
@@ -1978,10 +1958,6 @@
         ]
       },
       {
-        "expression": "asin([1, [0, 0.19866933079506123]])",
-        "result": [1.5707963267948966, [0, 0.2]]
-      },
-      {
         "expression": "atan2(arrayNum, 10)",
         "result": [
           -0.32172055409664824, -0.21845717120535865, -0.10955952677394436, 0,
@@ -2006,10 +1982,6 @@
       {
         "expression": "codePoint([\"A\", [\"B\", \"C\"]])",
         "result": [65, [66, 67]]
-      },
-      {
-        "expression": "cos([1, [2, 3]])",
-        "result": [0.5403023058681398, [-0.4161468365471424, -0.9899924966004454]]
       },
       {
         "expression": "now() | datedif([@, [@, @]], [@ + 1, [@ + 2, @ + 3]], \"d\")",
@@ -2184,48 +2156,26 @@
          "result": 3
        },
        {
-         "expression": "acos([0, [0, 0]])",
-         "result": [1.5707963267948966, [1.5707963267948966, 1.5707963267948966]]
-       },
-       {
          "expression": "asin([1, [0, 0.19866933079506123]])",
          "result": [1.5707963267948966, [0, 0.2]]
         },
         {
-
-         "expression": "atan2(1, [1, [2, 3]])",
-         "result": [0.7853981633974483, [0.4636476090008061, 0.3217505543966422]]
-        },
-        {
-
          "expression": "casefold(arrayStr)",
          "result": ["abc", "bcd", "cde", "def", "efg"]
-        },
-        {
-         "expression": "ceil([1.1, [2.2, 3.3]])",
-         "result": [2, [3, 4]]
         },
         {
           "expression": "ceil(arrayNum)",
          "result": [-3, -2, -1, 0, 2, 3, 4]
         },
         {
-
-         "expression": "codePoint([\"A\", [\"B\", \"C\"]])",
-         "result": [65, [66, 67]]
-        },
-        {
-
          "expression": "codePoint(arrayStr)",
          "result": [97, 98, 99, 100, 101]
         },
         {
-
          "expression": "cos([1, [2, 3]])",
          "result": [0.5403023058681398, [-0.4161468365471424, -0.9899924966004454]]
         },
         {
-
          "expression": "cos(arrayNum)",
          "result": [
            -0.9817374728267503, -0.6045522710579296, 0.4535961214255773, 1,
@@ -2233,22 +2183,18 @@
          ]
         },
         {
-
          "expression": "now() | datedif([@, [@, @]], [@ + 1, [@ + 2, @ + 3]], \"d\")",
          "result": [1, [2, 3]]
         },
         {
-
          "expression": "now() | datedif(@, @ + 1, [\"y\",\"m\",\"d\",\"ym\",\"yd\"])",
          "result": [0, 0, 1, 0, 1]
         },
         {
-
          "expression": "datetime(2024, 3, 8) | day([[@, @], [@, @]])",
          "result": [[8, 8], [8, 8]]
         },
         {
-
          "expression": "now() | datedif([@, @], [@ + 1, @ + 2], \"d\")",
          "result": [1, 2]
         },

--- a/test/functions.json
+++ b/test/functions.json
@@ -138,8 +138,7 @@
       },
       {
         "expression": "abs(`false`)",
-        "result": 0,
-        "was": "TypeError"
+        "error": "TypeError"
       },
       {
         "expression": "abs(`-24`)",
@@ -264,8 +263,7 @@
       },
       {
         "expression": "endsWith(str, `0`)",
-        "result": false,
-        "was": "TypeError"
+        "error": "TypeError"
       },
       {
         "expression": "floor(`1.2`)",
@@ -733,8 +731,7 @@
       },
       {
         "expression": "startsWith(str, `0`)",
-        "result": false,
-        "was": "TypeError"
+        "error": "TypeError"
       },
       {
         "expression": "sum(numbers)",
@@ -1751,6 +1748,381 @@
       {
         "expression": "zip(&[1,2,3], [4,5,6])",
         "error": "TypeError"
+      }
+    ]
+  },
+  {
+    "given": {
+      "num": 3,
+      "arrayNum": [-3.333, -2.22, -1.1, 0, 1.1, 2.22, 3.333],
+      "arrayInt": [1,2,3,4,5,6,7],
+      "str": "abcdefg",
+      "arrayStr": ["abc", "bcd", "cde", "def", "efg"]
+    },
+    "cases": [
+      {
+        "expression": "abs(arrayNum)",
+        "result": [3.333, 2.22, 1.1, 0, 1.1, 2.22, 3.333]
+      },
+      {
+        "expression": "acos(arrayInt / (arrayInt + 1))",
+        "result": [
+          1.0471975511965979, 0.8410686705679303, 0.7227342478134157,
+          0.6435011087932843, 0.5856855434571508, 0.5410995259571458,
+          0.5053605102841573
+        ]
+      },
+      {
+        "expression": "asin(arrayInt / (arrayInt + 1))",
+        "result": [
+          0.5235987755982989, 0.7297276562269663, 0.848062078981481,
+          0.9272952180016123, 0.9851107833377457, 1.0296968008377507,
+          1.0654358165107394
+        ]
+      },
+      {
+        "expression": "atan2(arrayNum, 10)",
+        "result": [
+          -0.32172055409664824, -0.21845717120535865, -0.10955952677394436, 0,
+          0.10955952677394436, 0.21845717120535865, 0.32172055409664824
+        ]
+      },
+      {
+        "expression": "atan2(arrayNum, arrayInt)",
+        "result": [
+          -1.2793120068559851, -0.837483712611627, -0.3514447940035517, 0,
+          0.2165503049760893, 0.35437991912343786, 0.44438039217805514
+        ]
+      },
+      {
+        "expression": "casefold(arrayStr)",
+        "result": ["abc", "bcd", "cde", "def", "efg"]
+      },
+      {
+        "expression": "ceil(arrayNum)",
+        "result": [-3, -2, -1, 0, 2, 3, 4]
+      },
+      {
+        "expression": "codePoint(arrayStr)",
+        "result": [97, 98, 99, 100, 101]
+      },
+      {
+        "expression": "cos(arrayNum)",
+        "result": [
+          -0.9817374728267503, -0.6045522710579296, 0.4535961214255773, 1,
+          0.4535961214255773, -0.6045522710579296, -0.9817374728267503
+        ]
+      },
+      {
+        "expression": "now() | datedif(@, @ + 1, [\"y\",\"m\",\"d\",\"ym\",\"yd\"])",
+        "result": [0, 0, 1, 0, 1]
+      },
+      {
+        "expression": "now() | datedif([@, @], [@ + 1, @ + 2], \"d\")",
+        "result": [1, 2]
+      },
+
+
+
+      {
+        "expression": "datetime(2024, 10, 12) | day([@, @ + 1])",
+        "result": [12, 13]
+      },
+      {
+        "expression": "endsWith(arrayStr, arrayStr)",
+        "result": [true, true, true, true, true]
+      },
+      {
+        "expression": "endsWith(arrayStr, \"c\")",
+        "result": [true, false, false, false, false]
+      },
+      {
+        "expression": "datetime(2024, 10, 12) | eomonth([@, @, @, @, @, @, @], 1)",
+        "result": [
+          20056.958333333332, 20056.958333333332, 20056.958333333332,
+          20056.958333333332, 20056.958333333332, 20056.958333333332,
+          20056.958333333332
+        ]
+      },
+      {
+        "expression": "{d: datetime(2024, 10, 12), n:arrayInt} | eomonth([@.d, @.d, @.d, @.d, @.d, @.d, @.d], @.n)",
+        "result": [
+          20056.958333333332, 20087.958333333332, 20118.958333333332,
+          20146.958333333332, 20177.916666666668, 20207.916666666668,
+          20238.916666666668
+        ]
+      },
+      {
+        "expression": "exp(arrayInt)",
+        "result": [
+          2.718281828459045, 7.38905609893065, 20.085536923187668,
+          54.598150033144236, 148.4131591025766, 403.4287934927351,
+          1096.6331584284585
+        ]
+      },
+      {
+        "expression": "find(arrayStr, arrayStr, [0,0,0,0,0,0])",
+        "result": [0, 0, 0, 0, 0, 0]
+      },
+      {
+        "expression": "find(\"c\", [\"cc\",\"ccc\",\"cccc\",\"ccccc\",\"cccccc\",\"ccccccc\",\"cccccccc\"], arrayInt)",
+        "result": [1, 2, 3, 4, 5, 6, 7]
+      },
+      {
+        "expression": "find(arrayStr, arrayStr, 0)",
+        "result": [0, 0, 0, 0, 0]
+      },
+      {
+        "expression": "find(\"c\", \"abcdefg\", arrayInt)",
+        "result": [2, 2, null, null, null, null, null]
+      },
+      {
+        "expression": "floor(arrayNum)",
+        "result": [-4, -3, -2, 0, 1, 2, 3]
+      },
+      {
+        "expression": "fromCodePoint(64 + arrayInt)",
+        "result": "ABCDEFG"
+      },
+      {
+        "expression": "fround(arrayNum)",
+        "result": [
+          -3.3329999446868896, -2.2200000286102295, -1.100000023841858, 0,
+          1.100000023841858, 2.2200000286102295, 3.3329999446868896
+        ]
+      },
+      {
+        "expression": "datetime(2024, 10, 12, 13) | hour([@, @])",
+        "result": [13, 13]
+      },
+      {
+        "expression": "log(arrayInt)",
+        "result": [
+          0, 0.6931471805599453, 1.0986122886681096, 1.3862943611198906,
+          1.6094379124341003, 1.791759469228055, 1.9459101490553132
+        ]
+      },
+      {
+        "expression": "log10(arrayInt)",
+        "result": [
+          0, 0.3010299956639812, 0.47712125471966244, 0.6020599913279624,
+          0.6989700043360189, 0.7781512503836436, 0.8450980400142568
+        ]
+      },
+      {
+        "expression": "lower(arrayStr)",
+        "result": ["abc", "bcd", "cde", "def", "efg"]
+      },
+      {
+        "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | millisecond([@, @ + 1])",
+        "result": [16, 16]
+      },
+      {
+        "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | minute([@, @ + 1])",
+        "result": [14, 14]
+      },
+      {
+        "expression": "mod(arrayInt, 2)",
+        "result": [1, 0, 1, 0, 1, 0, 1]
+      },
+      {
+        "expression": "mod(arrayInt, arrayInt + 1)",
+        "result": [1, 2, 3, 4, 5, 6, 7]
+      },
+      {
+        "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | month([@, @])",
+        "result": [10, 10]
+      },
+      {
+        "expression": "power(arrayInt, arrayInt)",
+        "result": [1, 4, 27, 256, 3125, 46656, 823543]
+      },
+      {
+        "expression": "power(arrayInt, 2)",
+        "result": [1, 4, 9, 16, 25, 36, 49]
+      },
+      {
+        "expression": "power(2, arrayInt)",
+        "result": [2, 4, 8, 16, 32, 64, 128]
+      },
+      {
+        "expression": "proper(arrayStr)",
+        "result": ["Abc", "Bcd", "Cde", "Def", "Efg"]
+      },
+      {
+        "expression": "rept(arrayStr, arrayInt)",
+        "result": [
+          "abc",
+          "bcdbcd",
+          "cdecdecde",
+          "defdefdefdef",
+          "efgefgefgefgefg",
+          "",
+          ""
+        ]
+      },
+      {
+        "expression": "rept(arrayStr, 2)",
+        "result": ["abcabc", "bcdbcd", "cdecde", "defdef", "efgefg"]
+      },
+      {
+        "expression": "rept(\"a\", arrayInt)",
+        "result": ["a", "aa", "aaa", "aaaa", "aaaaa", "aaaaaa", "aaaaaaa"]
+      },
+      {
+        "expression": "round(arrayNum)",
+        "result": [-3, -2, -1, 0, 1, 2, 3]
+      },
+      {
+        "expression": "search(arrayStr, arrayStr, [0,0,0,0,0])",
+        "result": [
+          [0, "abc"],
+          [0, "bcd"],
+          [0, "cde"],
+          [0, "def"],
+          [0, "efg"]
+        ]
+      },
+      {
+        "expression": "search(\"c\", arrayStr, [0,1,2,3,4,5])",
+        "result": [[2, "c"], [1, "c"], [], [], [], []]
+      },
+      {
+        "expression": "search(arrayStr, arrayStr, 0)",
+        "result": [
+          [0, "abc"],
+          [0, "bcd"],
+          [0, "cde"],
+          [0, "def"],
+          [0, "efg"]
+        ]
+      },
+      {
+        "expression": "search(arrayStr, \"abcdefg\", [0,1,2,3])",
+        "result": [
+          [0, "abc"],
+          [1, "bcd"],
+          [2, "cde"],
+          [3, "def"],
+          [4, "efg"]
+        ]
+      },
+      {
+        "expression": "search(\"b\", \"abcbebg\", [0,1,2,3])",
+        "result": [
+          [1, "b"],
+          [1, "b"],
+          [3, "b"],
+          [3, "b"]
+        ]
+      },
+      {
+        "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | second([@, @])",
+        "result": [15, 15]
+      },
+      {
+        "expression": "sign(arrayInt)",
+        "result": [1, 1, 1, 1, 1, 1, 1]
+      },
+      {
+        "expression": "sin(arrayNum)",
+        "result": [
+          0.19024072762619915, -0.7965654722360865, -0.8912073600614354, 0,
+          0.8912073600614354, 0.7965654722360865, -0.19024072762619915
+        ]
+      },
+      {
+        "expression": "split(arrayStr, \"\")",
+        "result": [
+          ["a", "b", "c"],
+          ["b", "c", "d"],
+          ["c", "d", "e"],
+          ["d", "e", "f"],
+          ["e", "f", "g"]
+        ]
+      },
+      {
+        "expression": "split(\"abcdefg\", [\"b\", \"c\"])",
+        "result": [
+          ["a", "cdefg"],
+          ["ab", "defg"]
+        ]
+      },
+      {
+        "expression": "split(arrayStr, [\"a\", \"b\"])",
+        "result": [
+          ["", "bc"],
+          ["", "cd"],
+          ["c", "d", "e"],
+          ["d", "e", "f"],
+          ["e", "f", "g"]
+        ]
+      },
+      {
+        "expression": "sqrt(arrayNum[?@ > 0])",
+        "result": [
+          1.0488088481701516,
+          1.489966442575134,
+          1.8256505689753448
+        ]
+      },
+      {
+        "expression": "startsWith(arrayStr, arrayStr)",
+        "result": [true,
+        true,
+        true,
+        true,
+        true]
+      },
+      {
+        "expression": "startsWith(arrayStr, \"b\")",
+        "result": [
+          false,
+          true,
+          false,
+          false,
+          false
+        ]
+      },
+      {
+        "expression": "startsWith(\"abcdefg\", [\"a\", \"b\", \"c\"])",
+        "result": [
+          true,
+          false,
+          false
+        ]
+      },
+      {
+        "expression": "substitute(arrayStr, \"c\", \"C\", [0,0,0,0,0])",
+        "result": ["abC","bCd","Cde","def","efg"]
+      },
+      {
+        "expression": "tan(arrayNum)",
+        "result": [-0.1937796334476594, 1.3176122402817965, -1.9647596572486523, 0, 1.9647596572486523, -1.3176122402817965, 0.1937796334476594]
+      },
+      {
+        "expression": "trim(arrayStr)",
+        "result": ["abc", "bcd", "cde", "def", "efg"]
+      },
+      {
+        "expression": "trunc(arrayNum, [1,1,0,0,0,1,1])",
+        "result": [-3.3, -2.2, -1, 0, 1, 2.2, 3.3]
+      },
+      {
+        "expression": "trunc(arrayNum)",
+        "result": [-3, -2, -1, 0, 1, 2, 3]
+      },
+      {
+        "expression": "upper(arrayStr)",
+        "result": ["ABC", "BCD", "CDE", "DEF", "EFG"]
+      },
+      {
+        "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | weekday([@, @ + 1], 1)",
+        "result": [7, 1]
+      },
+      {
+        "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | year([@, @ + 1])",
+        "result": [2024, 2024]
       }
     ]
   }

--- a/test/functions.json
+++ b/test/functions.json
@@ -170,7 +170,7 @@
       },
       {
         "expression": "avg('abc')",
-        "error": "EvaluationError"
+        "error": "TypeError"
       },
       {
         "expression": "avg(foo)",
@@ -195,7 +195,7 @@
       },
       {
         "expression": "avg(`null`)",
-        "error": "EvaluationError"
+        "error": "TypeError"
       },
       {
         "expression": "ceil(`1.2`)",
@@ -635,7 +635,7 @@
       },
       {
         "expression": "keys(`null`)",
-        "result": []
+        "error": "TypeError"
       },
       {
         "expression": "values(foo)",
@@ -643,7 +643,7 @@
       },
       {
         "expression": "values(null())",
-        "result": []
+        "error": "TypeError"
       },
       {
         "expression": "join(strings, \", \")",
@@ -1287,8 +1287,7 @@
       },
       {
         "expression": "map(badkey, &a)",
-        "result": [],
-        "was": "TypeError"
+        "error": "TypeError"
       },
       {
         "expression": "map(empty, &foo)",

--- a/test/functions.json
+++ b/test/functions.json
@@ -138,7 +138,7 @@
       },
       {
         "expression": "abs(`false`)",
-        "error": "TypeError"
+        "result": 0
       },
       {
         "expression": "abs(`-24`)",
@@ -263,7 +263,7 @@
       },
       {
         "expression": "endsWith(str, `0`)",
-        "error": "TypeError"
+        "result": false
       },
       {
         "expression": "floor(`1.2`)",
@@ -731,7 +731,7 @@
       },
       {
         "expression": "startsWith(str, `0`)",
-        "error": "TypeError"
+        "result": false
       },
       {
         "expression": "sum(numbers)",
@@ -1837,20 +1837,12 @@
         "result": [true, false, false, false, false]
       },
       {
-        "expression": "datetime(2024, 10, 12) | eomonth([@, @, @, @, @, @, @], 1)",
-        "result": [
-          20056.958333333332, 20056.958333333332, 20056.958333333332,
-          20056.958333333332, 20056.958333333332, 20056.958333333332,
-          20056.958333333332
-        ]
+        "expression": "datetime(2024, 10, 12) | eomonth([@, @, @, @, @, @, @], 1)| [month(@) & day(@)][]",
+        "result": ["1130", "1130", "1130", "1130", "1130", "1130", "1130"]
       },
       {
-        "expression": "{d: datetime(2024, 10, 12), n:arrayInt} | eomonth([@.d, @.d, @.d, @.d, @.d, @.d, @.d], @.n)",
-        "result": [
-          20056.958333333332, 20087.958333333332, 20118.958333333332,
-          20146.958333333332, 20177.916666666668, 20207.916666666668,
-          20238.916666666668
-        ]
+        "expression": "{d: datetime(2024, 10, 12), n:arrayInt} | eomonth([@.d, @.d, @.d, @.d, @.d, @.d, @.d], @.n) | [month(@) & day(@)][]",
+        "result": ["1130", "1231", "131", "228", "331", "430", "531"]
       },
       {
         "expression": "exp(arrayInt)",

--- a/test/functions.json
+++ b/test/functions.json
@@ -2024,8 +2024,8 @@
         "result": [true, [false, false]]
       },
       {
-        "expression": "datetime(2024, 3, 8) | eomonth([[@, @], [@, @]], 1)",
-        "result": [[19843.166666666668, 19843.166666666668], [19843.166666666668, 19843.166666666668]]
+        "expression": "datetime(2024, 3, 8) | eomonth([[@, @], [@, @]], 1) | month(@) & \"/\" &day(@)",
+        "result": [["4/30", "4/30"], ["4/30", "4/30"]]
       },
       {
         "expression": "exp([1, [2, 3]])",
@@ -2261,52 +2261,38 @@
          "result": [12, 13]
         },
         {
-
-         "expression": "datetime(2024, 3, 8) | eomonth([[@, @], [@, @]], 1)",
-         "result": [[19843.166666666668, 19843.166666666668], [19843.166666666668, 19843.166666666668]]
-        },
-        {
-
          "expression": "endsWith(arrayStr, arrayStr)",
          "result": [true, true, true, true, true]
         },
         {
-
          "expression": "exp([1, [2, 3]])",
          "result": [2.718281828459045, [7.38905609893065, 20.085536923187668]]
         },
         {
-
          "expression": "endsWith(arrayStr, \"c\")",
          "result": [true, false, false, false, false]
         },
         {
-
          "expression": "find(\"a\", [\"abc\", [\"def\", \"ghi\"]], [0, [1, 2]])",
          "result": [0, [null, null]]
         },
         {
-
          "expression": "datetime(2024, 10, 12) | eomonth([@, @, @, @, @, @, @], 1)| [month(@) & day(@)][]",
          "result": ["1130", "1130", "1130", "1130", "1130", "1130", "1130"]
         },
         {
-
          "expression": "floor([1.1, [2.2, 3.3]])",
          "result": [1, [2, 3]]
        },
        {
-
          "expression": "{d: datetime(2024, 10, 12), n:arrayInt} | eomonth([@.d, @.d, @.d, @.d, @.d, @.d, @.d], @.n) | [month(@) & day(@)][]",
          "result": ["1130", "1231", "131", "228", "331", "430", "531"]
         },
         {
-
          "expression": "fround([1.1, [2.2, 3.3]])",
          "result": [1.100000023841858, [2.200000047683716, 3.299999952316284]]
         },
         {
-
          "expression": "exp(arrayInt)",
          "result": [
            2.718281828459045, 7.38905609893065, 20.085536923187668,
@@ -2315,42 +2301,34 @@
          ]
         },
         {
-
          "expression": "datetime(2024, 3, 8, 13, 45) | hour([[@, @], [@, @]])",
          "result": [[13, 13], [13, 13]]
         },
         {
-
          "expression": "find(arrayStr, arrayStr, [0,0,0,0,0,0])",
          "result": [0, 0, 0, 0, 0, 0]
         },
         {
-
          "expression": "log([1, [2, 3]])",
          "result": [0, [0.6931471805599453, 1.0986122886681096]]
         },
         {
-
          "expression": "find(\"c\", [\"cc\",\"ccc\",\"cccc\",\"ccccc\",\"cccccc\",\"ccccccc\",\"cccccccc\"], arrayInt)",
          "result": [1, 2, 3, 4, 5, 6, 7]
         },
         {
-
          "expression": "log10([1, [2, 3]])",
          "result": [0, [0.3010299956639812, 0.47712125471966244]]
         },
         {
-
          "expression": "find(arrayStr, arrayStr, 0)",
          "result": [0, 0, 0, 0, 0]
         },
         {
-
          "expression": "lower([\"ABC\", [\"DEF\", \"GHI\"]])",
          "result": ["abc", ["def", "ghi"]]
         },
         {
-
          "expression": "find(\"c\", \"abcdefg\", arrayInt)",
          "result": [2, 2, null, null, null, null, null]
         },
@@ -2371,12 +2349,10 @@
          "result": "ABCDEFG"
         },
         {
-
          "expression": "min([2, [1, 3]])",
          "result": 1
         },
         {
-
          "expression": "fround(arrayNum)",
          "result": [
            -3.3329999446868896, -2.2200000286102295, -1.100000023841858, 0,
@@ -2384,22 +2360,18 @@
          ]
         },
         {
-
          "expression": "datetime(2024, 3, 8, 13, 45) | minute([[@, @], [@, @]])",
          "result": [[45, 45], [45, 45]]
         },
         {
-
          "expression": "datetime(2024, 10, 12, 13) | hour([@, @])",
          "result": [13, 13]
         },
         {
-
          "expression": "mod([2, [4, 6]], [1, [2, 3]])",
          "result": [0, [0, 0]]
         },
         {
-
          "expression": "log(arrayInt)",
          "result": [
            0, 0.6931471805599453, 1.0986122886681096, 1.3862943611198906,
@@ -2407,12 +2379,10 @@
          ]
         },
         {
-
          "expression": "datetime(2024, 3, 8) | month([[@, @], [@, @]])",
          "result": [[3, 3], [3, 3]]
         },
         {
-
          "expression": "log10(arrayInt)",
          "result": [
            0, 0.3010299956639812, 0.47712125471966244, 0.6020599913279624,
@@ -2420,112 +2390,90 @@
          ]
         },
         {
-
          "expression": "power([2, [3, 4]], [2, [2, 2]])",
          "result": [4, [9, 16]]
         },
         {
-
          "expression": "lower(arrayStr)",
          "result": ["abc", "bcd", "cde", "def", "efg"]
         },
         {
-
          "expression": "proper([\"abc\", [\"def\", \"ghi\"]])",
          "result": ["Abc", ["Def", "Ghi"]]
         },
         {
-
          "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | millisecond([@, @ + 1])",
          "result": [16, 16]
         },
         {
-
          "expression": "rept([\"a\", [\"b\", \"c\"]], [2, [2, 2]])",
          "result": ["aa", ["bb", "cc"]]
         },
         {
-
          "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | minute([@, @ + 1])",
          "result": [14, 14]
         },
         {
-
          "expression": "round([1.5, [2.5, 3.5]])",
          "result": [2, [3, 4]]
         },
         {
-
          "expression": "mod(arrayInt, 2)",
          "result": [1, 0, 1, 0, 1, 0, 1]
         },
         {
-
          "expression": "search(\"a\", [\"abc\", [\"def\", \"ghi\"]], [0, [0, 0]])",
          "result": [[0, "a"], [[], []]]
         },
         {
-
          "expression": "mod(arrayInt, arrayInt + 1)",
          "result": [1, 2, 3, 4, 5, 6, 7]
         },
         {
-
          "expression": "datetime(2024, 3, 8, 13, 45, 30) | second([[@, @], [@, @]])",
          "result": [[30, 30], [30, 30]]
         },
         {
-
          "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | month([@, @])",
          "result": [10, 10]
         },
         {
-
          "expression": "sign([1.1, [-2.2, 3.3]])",
          "result": [1, [-1, 1]]
         },
         {
-
          "expression": "power(arrayInt, arrayInt)",
          "result": [1, 4, 27, 256, 3125, 46656, 823543]
         },
         {
-
          "expression": "sin([1, [2, 3]])",
          "result": [0.8414709848078965, [0.9092974268256817, 0.1411200080598672]]
         },
         {
-
          "expression": "power(arrayInt, 2)",
          "result": [1, 4, 9, 16, 25, 36, 49]
         },
         {
-
          "expression": "split([\"a,b\", [\"c,d\", \"e,f\"]], \",\")",
          "result": [["a", "b"], [["c", "d"], ["e", "f"]]]
         },
         {
-
          "expression": "power(2, arrayInt)",
          "result": [2, 4, 8, 16, 32, 64, 128]
         },
         {
-
          "expression": "sqrt([4, [9, 16]])",
          "result": [2, [3, 4]]
         },
         {
-
          "expression": "proper(arrayStr)",
          "result": ["Abc", "Bcd", "Cde", "Def", "Efg"]
         },
         {
-
          "expression": "startsWith([\"abc\", [\"def\", \"ghi\"]], \"a\")",
          "result": [true, [false, false]]
         },
         {
-
          "expression": "rept(arrayStr, arrayInt)",
          "result": [
            "abc",
@@ -2538,42 +2486,34 @@
          ]
         },
         {
-
          "expression": "stdev([1, [2, 3]])",
          "result": 1
         },
         {
-
          "expression": "rept(arrayStr, 2)",
          "result": ["abcabc", "bcdbcd", "cdecde", "defdef", "efgefg"]
         },
         {
-
          "expression": "stdevA([1, [2, 3]])",
          "result": 1
         },
         {
-
          "expression": "rept(\"a\", arrayInt)",
          "result": ["a", "aa", "aaa", "aaaa", "aaaaa", "aaaaaa", "aaaaaaa"]
         },
         {
-
          "expression": "stdevp([1, [2, 3]])",
          "result": 0.8164965809277263
         },
         {
-
          "expression": "round(arrayNum)",
          "result": [-3, -2, -1, 0, 1, 2, 3]
         },
         {
-
          "expression": "stdevpA([1, [2, 3]])",
          "result": 0.8164965809277263
         },
         {
-
          "expression": "search(arrayStr, arrayStr, [0,0,0,0,0])",
          "result": [
            [0, "abc"],
@@ -2584,22 +2524,18 @@
          ]
         },
         {
-
          "expression": "substitute([\"abc\", [\"aab\", \"ghi\"]], \"a\", \"A\", [0, [1, 0]])",
          "result": ["Abc", ["aAb", "ghi"]]
         },
         {
-
          "expression": "search(\"c\", arrayStr, [0,1,2,3,4,5])",
          "result": [[2, "c"], [1, "c"], [], [], [], []]
         },
         {
-
          "expression": "sum([1, [2, 3]])",
          "result": 6
         },
         {
-
          "expression": "search(arrayStr, arrayStr, 0)",
          "result": [
            [0, "abc"],
@@ -2610,12 +2546,10 @@
          ]
         },
         {
-
          "expression": "tan([1, [2, 3]])",
          "result": [1.5574077246549023, [-2.185039863261519, -0.1425465430742778]]
         },
         {
-
          "expression": "search(arrayStr, \"abcdefg\", [0,1,2,3])",
          "result": [
            [0, "abc"],
@@ -2626,12 +2560,10 @@
          ]
         },
         {
-
          "expression": "trim([\" abc \", [\" def \", \" ghi \"]])",
          "result": ["abc", ["def", "ghi"]]
         },
         {
-
          "expression": "search(\"b\", \"abcbebg\", [0,1,2,3])",
          "result": [
            [1, "b"],
@@ -2641,32 +2573,26 @@
          ]
         },
         {
-
          "expression": "trunc([1.5, [2.5, 3.5]])",
          "result": [1, [2, 3]]
         },
         {
-
          "expression": "datetime(2024, 10, 12, 13, 14, 15, 16) | second([@, @])",
          "result": [15, 15]
         },
         {
-
          "expression": "upper([\"abc\", [\"def\", \"ghi\"]])",
          "result": ["ABC", ["DEF", "GHI"]]
         },
         {
-
          "expression": "sign(arrayInt)",
          "result": [1, 1, 1, 1, 1, 1, 1]
         },
         {
-
          "expression": "datetime(2024, 3, 8) | weekday([[@, @], [@, @]], 1)",
          "result": [[6, 6], [6, 6]]
         },
         {
-
          "expression": "sin(arrayNum)",
          "result": [
            0.19024072762619915, -0.7965654722360865, -0.8912073600614354, 0,
@@ -2674,12 +2600,10 @@
          ]
         },
         {
-
          "expression": "datetime(2024, 3, 8) | year([[@, @], [@, @]])",
          "result": [[2024, 2024], [2024, 2024]]
         },
         {
-
          "expression": "split(arrayStr, \"\")",
          "result": [
            ["a", "b", "c"],

--- a/test/specSamples.json
+++ b/test/specSamples.json
@@ -12,7 +12,7 @@
       { "expression": "[1,2,3] ~ 4", "result": [1, 2, 3, 4] },
       { "expression": "123 < \"124\"", "result": true },
       { "expression": "\"23\" > 111", "result": false },
-      { "expression": "abs(\"-2\")", "result": 2 },
+      { "expression": "avg([\"2\", \"3\", \"4\"])", "result": 3 },
       { "expression": "1 == \"1\"", "result": false },
       { "expression": "\"$123.00\" + 1", "error": "TypeError" },
       {

--- a/test/specSamples.json
+++ b/test/specSamples.json
@@ -12,7 +12,7 @@
       { "expression": "[1,2,3] ~ 4", "result": [1, 2, 3, 4] },
       { "expression": "123 < \"124\"", "result": true },
       { "expression": "\"23\" > 111", "result": false },
-      { "expression": "avg([\"2\", \"3\", \"4\"])", "result": 3 },
+      { "expression": "avg([\"2\", \"3\", \"4\"])", "error": "EvaluationError" },
       { "expression": "1 == \"1\"", "result": false },
       { "expression": "\"$123.00\" + 1", "error": "TypeError" },
       {
@@ -65,7 +65,7 @@
         "result": { "month": 1, "day": 21, "hour": 12 }
       },
       { "expression": "2 + `true`", "result": 3 },
-      { "expression": "avg([\"20\", \"30\"])", "result": 25 },
+      { "expression": "avg([\"20\", \"30\"])", "error": "EvaluationError" },
       {
         "expression": "left + right",
         "data": { "left": 8, "right": 12 },

--- a/test/specSamples.json
+++ b/test/specSamples.json
@@ -65,7 +65,7 @@
         "result": { "month": 1, "day": 21, "hour": 12 }
       },
       { "expression": "2 + `true`", "result": 3 },
-      { "expression": "avg(\"20\")", "result": 20 },
+      { "expression": "avg([\"20\", \"30\"])", "result": 25 },
       {
         "expression": "left + right",
         "data": { "left": 8, "right": 12 },

--- a/test/specSamples.json
+++ b/test/specSamples.json
@@ -41,7 +41,7 @@
       {
         "expression": "a ~ `null`",
         "data": { "a": [0, 1, 2] },
-        "result": [0, 1, 2]
+        "result": [0, 1, 2, null]
       },
       {
         "expression": "\"truth is \" & `true`",

--- a/test/tests.json
+++ b/test/tests.json
@@ -1582,15 +1582,15 @@
         "error": "FunctionError"
       },
       {
-        "expression": "_product([3, 4]) + _product([4, 5])",
-        "result": 32
-      },
-      {
         "expression": "merge(register(\"_p1\", &42), register(\"_p2\", &43), {r: _p1() + _p2()})",
         "result": { "r": 85 }
       },
       {
         "expression": "register(\"_identity\", &@) || _identity()",
+        "result": null
+      },
+      {
+        "expression": "registerWithParams(\"Identity\", &if (length(@) = 0, null(), @)) || Identity()",
         "result": null
       },
       {

--- a/test/tests.json
+++ b/test/tests.json
@@ -781,9 +781,19 @@
         "expression": "sqrt(missing)",
         "result": 0
       },
-      { "expression": "stdev(`[1,\"2\",3]`)", "result": 1 },
+      { "expression": "stdev(`[1,\"2\",2,3]`)", "result": 1 },
+      { "expression": "stdev(`[1,[\"2\",[2,3]]]`)", "result": 1 },
       { "expression": "stdev(`[1]`)", "error": "EvaluationError" },
       { "expression": "stdev(`[]`)", "error": "EvaluationError" },
+      {
+        "data": "'purchase-order'",
+        "expression": "stdev(items[*].quantity)",
+        "result": 0.7071067811865476
+      },
+      { "expression": "stdevA(`[\"1\",2,3]`)", "result": 1 },
+      { "expression": "stdevA(`[1,[[\"2\",3]]]`)", "result": 1 },
+      { "expression": "stdevA(`[1]`)", "error": "EvaluationError" },
+      { "expression": "stdevA(`[]`)", "error": "EvaluationError" },
       {
         "data": "'purchase-order'",
         "expression": "stdev(items[*].quantity)",
@@ -795,6 +805,7 @@
         "error": "TypeError"
       },
       { "expression": "stdevp(`[2,3]`)", "result": 0.5 },
+      { "expression": "stdevp(`[2,[3]]`)", "result": 0.5 },
       { "expression": "stdevp(`[2]`)", "result": 0 },
       { "expression": "stdevp(`[]`)", "error": "EvaluationError" },
       {

--- a/test/tests.json
+++ b/test/tests.json
@@ -349,7 +349,7 @@
       {
         "data": "'purchase-order'",
         "expression": "lower(address.missing)",
-        "result": ""
+        "error": "TypeError"
       },
       {
         "data": "'purchase-order'",
@@ -359,11 +359,11 @@
       { "expression": "lower(\"\")", "result": "" },
       { "expression": "lower(\"abc\")", "result": "abc" },
       { "expression": "lower(\"aBc\")", "result": "abc" },
-      { "expression": "lower(42)", "result": "42" },
+      { "expression": "lower(42)", "error": "TypeError" },
       {
         "data": "'purchase-order'",
         "expression": "upper(address.missing)",
-        "result": ""
+        "error": "TypeError"
       },
       {
         "data": "'purchase-order'",
@@ -373,7 +373,7 @@
       { "expression": "upper(\"\")", "result": "" },
       { "expression": "upper(\"ABC\")", "result": "ABC" },
       { "expression": "upper(\"aBc\")", "result": "ABC" },
-      { "expression": "upper(42)", "result": "42" },
+      { "expression": "upper(42)", "error": "TypeError" },
       {
         "data": "'purchase-order'",
         "expression": "exp(items[0].quantity)",
@@ -382,10 +382,10 @@
       {
         "data": "'purchase-order'",
         "expression": "exp(missing)",
-        "result": 1
+        "error": "TypeError"
       },
       { "expression": "exp(0)", "result": 1 },
-      { "expression": "exp(\"0\")", "result": 1 },
+      { "expression": "exp(\"0\")", "error": "TypeError" },
       { "expression": "exp(1)", "result": 2.718281828459045 },
       {
         "data": "'purchase-order'",
@@ -395,7 +395,7 @@
       {
         "data": "'purchase-order'",
         "expression": "power(missing, 1)",
-        "result": 0
+        "error": "TypeError"
       },
       { "expression": "power(1, 1)", "result": 1 },
       { "expression": "power(2, 3)", "result": 8 },
@@ -450,17 +450,17 @@
       {
         "data": "'purchase-order'",
         "expression": "find(\"Oak\", missing)",
-        "result": null
+        "error": "TypeError"
       },
       {
         "data": "'purchase-order'",
         "expression": "find(missing, address.street)",
-        "result": 0
+        "error": "TypeError"
       },
       {
         "data": "'purchase-order'",
         "expression": "find(missing, missing)",
-        "result": 0
+        "error": "TypeError"
       },
       { "expression": "left(\"abc\")", "result": "a" },
       { "expression": "left(\"abc\", 1)", "result": "a" },
@@ -551,7 +551,7 @@
       },
       {
         "data": "'purchase-order'",
-        "expression": "left(split(address.street, ''))",
+        "expression": "left(split(address.street, \"\"))",
         "result": ["1"]
       },
       {
@@ -580,7 +580,7 @@
       },
       {
         "data": "'purchase-order'",
-        "expression": "right(split(address.street, ''))",
+        "expression": "right(split(address.street, \"\"))",
         "result": ["t"]
       },
       {
@@ -625,9 +625,9 @@
       {
         "data": "'purchase-order'",
         "expression": "proper(missing)",
-        "result": ""
+        "error": "TypeError"
       },
-      { "expression": "rept('', 10)", "result": "" },
+      { "expression": "rept(\"\", 10)", "result": "" },
       { "expression": "rept(\"a\", 2)", "result": "aa" },
       {
         "expression": "rept(\"abc\", 2)",
@@ -643,12 +643,12 @@
       {
         "data": "'purchase-order'",
         "expression": "rept(address.country,missing)",
-        "result": ""
+        "error": "TypeError"
       },
       {
         "data": "'purchase-order'",
         "expression": "rept(missing,3)",
-        "result": ""
+        "error": "TypeError"
       },
       {
         "expression": "replace(\"abcdefg\", 2, 2, \"yz\")",
@@ -753,12 +753,12 @@
       {
         "data": "'purchase-order'",
         "expression": "round(items[0].price, missing)",
-        "result": 3
+        "error": "TypeError"
       },
       {
         "data": "'purchase-order'",
         "expression": "round(missing, 1)",
-        "result": 0
+        "error": "TypeError"
       },
       { "expression": "round(1.5)", "result": 2 },
       { "expression": "round(-1.5)", "result": -1 },
@@ -779,7 +779,7 @@
       {
         "data": "'purchase-order'",
         "expression": "sqrt(missing)",
-        "result": 0
+        "error": "TypeError"
       },
       { "expression": "stdev(`[1,\"2\",3]`)", "result": 1 },
       { "expression": "stdev(`[1]`)", "error": "EvaluationError" },
@@ -823,7 +823,7 @@
       {
         "data": "'purchase-order'",
         "expression": "trim(missing)",
-        "result": ""
+        "error": "TypeError"
       },
       { "expression": "trunc(123.456)", "result": 123 },
       { "expression": "trunc(123.456, 1)", "result": 123.4 },
@@ -853,12 +853,12 @@
       {
         "data": "'purchase-order'",
         "expression": "trunc(items[0].price, missing)",
-        "result": 3
+        "error": "TypeError"
       },
       {
         "data": "'purchase-order'",
         "expression": "trunc(missing, 1)",
-        "result": 0
+        "error": "TypeError"
       },
       {
         "expression": "fromCodePoint(13055)",
@@ -876,7 +876,7 @@
       {
         "data": "'purchase-order'",
         "expression": "fromCodePoint(missing)",
-        "result": "\u0000"
+        "error": "TypeError"
       },
       { "expression": "codePoint(\"\\t\")", "result": 9 },
       { "expression": "codePoint(\"㋿\")", "result": 13055 },
@@ -888,7 +888,7 @@
       {
         "data": "'purchase-order'",
         "expression": "codePoint(missing)",
-        "result": null
+        "error": "TypeError"
       },
       {
         "data": "'purchase-order'",
@@ -1097,7 +1097,7 @@
       {
         "data": "casefold",
         "expression": "casefold(notfound)",
-        "result": ""
+        "error": "TypeError"
       },
       {
         "data": "casefold.test1",
@@ -1210,18 +1210,18 @@
       },
       {
         "data": "'purchase-order'",
-        "expression": "split(address.country, '')",
+        "expression": "split(address.country, \"\")",
         "result": ["U", "S", "A"]
       },
       {
         "data": "'purchase-order'",
         "expression": "split(address.country, `null`)",
-        "result": ["U", "S", "A"]
+        "error": "TypeError"
       },
       {
         "data": "'purchase-order'",
         "expression": "split(no, where)",
-        "result": []
+        "error": "TypeError"
       },
       {
         "data": "'purchase-order'",
@@ -1558,8 +1558,7 @@
         "expression": "search(\".\\\\\\\\^$(+{]\", \"pada.\\\\^$(+{]b\")",
         "result": [4, ".\\^$(+{]"]
       },
-      { "expression": "search(\"\", null)", "result": [] },
-      { "expression": "search(\"\", null)", "result": [] },
+      { "expression": "search(\"\", null)", "error": "TypeError" },
       { "expression": "search(\"a**a\", \"pada\")", "result": [1, "ada"]},
       { "expression": "search(\"a*?a\", \"pada\")", "result": [1, "ada"]},
       {

--- a/test/tests.json
+++ b/test/tests.json
@@ -349,7 +349,7 @@
       {
         "data": "'purchase-order'",
         "expression": "lower(address.missing)",
-        "error": "TypeError"
+        "result": ""
       },
       {
         "data": "'purchase-order'",
@@ -363,7 +363,7 @@
       {
         "data": "'purchase-order'",
         "expression": "upper(address.missing)",
-        "error": "TypeError"
+        "result": ""
       },
       {
         "data": "'purchase-order'",
@@ -382,7 +382,7 @@
       {
         "data": "'purchase-order'",
         "expression": "exp(missing)",
-        "error": "TypeError"
+        "result": 1
       },
       { "expression": "exp(0)", "result": 1 },
       { "expression": "exp(\"0\")", "result": 1 },
@@ -395,7 +395,7 @@
       {
         "data": "'purchase-order'",
         "expression": "power(missing, 1)",
-        "error": "TypeError"
+        "result": 0
       },
       { "expression": "power(1, 1)", "result": 1 },
       { "expression": "power(2, 3)", "result": 8 },
@@ -450,17 +450,17 @@
       {
         "data": "'purchase-order'",
         "expression": "find(\"Oak\", missing)",
-        "error": "TypeError"
+        "result": null
       },
       {
         "data": "'purchase-order'",
         "expression": "find(missing, address.street)",
-        "error": "TypeError"
+        "result": 0
       },
       {
         "data": "'purchase-order'",
         "expression": "find(missing, missing)",
-        "error": "TypeError"
+        "result": 0
       },
       { "expression": "left(\"abc\")", "result": "a" },
       { "expression": "left(\"abc\", 1)", "result": "a" },
@@ -476,7 +476,7 @@
       {
         "data": "'purchase-order'",
         "expression": "left(missing)",
-        "error": "TypeError"
+        "result": ""
       },
       { "expression": "right(\"abc\")", "result": "c" },
       { "expression": "right(\"abc\", 1)", "result": "c" },
@@ -495,7 +495,7 @@
       {
         "data": "'purchase-order'",
         "expression": "right(missing)",
-        "error": "TypeError"
+        "result": ""
       },
       { "expression": "mid(\"abc\", 0, 0)", "result": "" },
       { "expression": "mid(\"abc\", 1, 1)", "result": "b" },
@@ -523,7 +523,7 @@
       {
         "data": "'purchase-order'",
         "expression": "mid(missing, 0, 1)",
-        "error": "TypeError"
+        "result": ""
       },
       {
         "expression": "left(split(\"abc\", \"\"))",
@@ -625,7 +625,7 @@
       {
         "data": "'purchase-order'",
         "expression": "proper(missing)",
-        "error": "TypeError"
+        "result": ""
       },
       { "expression": "rept(\"\", 10)", "result": "" },
       { "expression": "rept(\"a\", 2)", "result": "aa" },
@@ -643,12 +643,12 @@
       {
         "data": "'purchase-order'",
         "expression": "rept(address.country,missing)",
-        "error": "TypeError"
+        "result": ""
       },
       {
         "data": "'purchase-order'",
         "expression": "rept(missing,3)",
-        "error": "TypeError"
+        "result": ""
       },
       {
         "expression": "replace(\"abcdefg\", 2, 2, \"yz\")",
@@ -683,7 +683,7 @@
       {
         "data": "'purchase-order'",
         "expression": "replace(missing,0, 1, address.country)",
-        "error": "TypeError"
+        "result": "USA"
       },
       {
         "expression": "replace([\"blue\",\"black\",\"white\",\"red\"], 1, 0, \"green\")",
@@ -753,12 +753,12 @@
       {
         "data": "'purchase-order'",
         "expression": "round(items[0].price, missing)",
-        "error": "TypeError"
+        "result": 3
       },
       {
         "data": "'purchase-order'",
         "expression": "round(missing, 1)",
-        "error": "TypeError"
+        "result": 0
       },
       { "expression": "round(1.5)", "result": 2 },
       { "expression": "round(-1.5)", "result": -1 },
@@ -779,7 +779,7 @@
       {
         "data": "'purchase-order'",
         "expression": "sqrt(missing)",
-        "error": "TypeError"
+        "result": 0
       },
       { "expression": "stdev(`[1,\"2\",3]`)", "result": 1 },
       { "expression": "stdev(`[1]`)", "error": "EvaluationError" },
@@ -792,7 +792,7 @@
       {
         "data": "'purchase-order'",
         "expression": "stdev(missing)",
-        "error": "EvaluationError"
+        "error": "TypeError"
       },
       { "expression": "stdevp(`[2,3]`)", "result": 0.5 },
       { "expression": "stdevp(`[2]`)", "result": 0 },
@@ -805,7 +805,7 @@
       {
         "data": "'purchase-order'",
         "expression": "stdevp(missing)",
-        "error": "EvaluationError"
+        "error": "TypeError"
       },
       {
         "expression": "trim(\"  abc  def ghi   \")",
@@ -823,7 +823,7 @@
       {
         "data": "'purchase-order'",
         "expression": "trim(missing)",
-        "error": "TypeError"
+        "result": ""
       },
       { "expression": "trunc(123.456)", "result": 123 },
       { "expression": "trunc(123.456, 1)", "result": 123.4 },
@@ -853,12 +853,12 @@
       {
         "data": "'purchase-order'",
         "expression": "trunc(items[0].price, missing)",
-        "error": "TypeError"
+        "result": 3
       },
       {
         "data": "'purchase-order'",
         "expression": "trunc(missing, 1)",
-        "error": "TypeError"
+        "result": 0
       },
       {
         "expression": "fromCodePoint(13055)",
@@ -876,7 +876,7 @@
       {
         "data": "'purchase-order'",
         "expression": "fromCodePoint(missing)",
-        "error": "TypeError"
+        "result": "\u0000"
       },
       { "expression": "codePoint(\"\\t\")", "result": 9 },
       { "expression": "codePoint(\"㋿\")", "result": 13055 },
@@ -888,7 +888,7 @@
       {
         "data": "'purchase-order'",
         "expression": "codePoint(missing)",
-        "error": "TypeError"
+        "result": null
       },
       {
         "data": "'purchase-order'",
@@ -1097,7 +1097,7 @@
       {
         "data": "casefold",
         "expression": "casefold(notfound)",
-        "error": "TypeError"
+        "result": ""
       },
       {
         "data": "casefold.test1",
@@ -1163,7 +1163,7 @@
       },
       {
         "expression": "fromEntries(`null`)",
-        "result": {}
+        "error": "TypeError"
       },
       {
         "expression": "fromEntries(`[]`)",
@@ -1216,12 +1216,12 @@
       {
         "data": "'purchase-order'",
         "expression": "split(address.country, `null`)",
-        "error": "TypeError"
+        "result": ["U","S","A"]
       },
       {
         "data": "'purchase-order'",
         "expression": "split(no, where)",
-        "error": "TypeError"
+        "result": []
       },
       {
         "data": "'purchase-order'",
@@ -1558,7 +1558,7 @@
         "expression": "search(\".\\\\\\\\^$(+{]\", \"pada.\\\\^$(+{]b\")",
         "result": [4, ".\\^$(+{]"]
       },
-      { "expression": "search(\"\", null)", "error": "TypeError" },
+      { "expression": "search(\"\", null)", "result": [] },
       { "expression": "search(\"a**a\", \"pada\")", "result": [1, "ada"]},
       { "expression": "search(\"a*?a\", \"pada\")", "result": [1, "ada"]},
       {

--- a/test/tests.json
+++ b/test/tests.json
@@ -359,7 +359,7 @@
       { "expression": "lower(\"\")", "result": "" },
       { "expression": "lower(\"abc\")", "result": "abc" },
       { "expression": "lower(\"aBc\")", "result": "abc" },
-      { "expression": "lower(42)", "error": "TypeError" },
+      { "expression": "lower(42)", "result": "42" },
       {
         "data": "'purchase-order'",
         "expression": "upper(address.missing)",
@@ -373,7 +373,7 @@
       { "expression": "upper(\"\")", "result": "" },
       { "expression": "upper(\"ABC\")", "result": "ABC" },
       { "expression": "upper(\"aBc\")", "result": "ABC" },
-      { "expression": "upper(42)", "error": "TypeError" },
+      { "expression": "upper(42)", "result": "42" },
       {
         "data": "'purchase-order'",
         "expression": "exp(items[0].quantity)",
@@ -385,7 +385,7 @@
         "error": "TypeError"
       },
       { "expression": "exp(0)", "result": 1 },
-      { "expression": "exp(\"0\")", "error": "TypeError" },
+      { "expression": "exp(\"0\")", "result": 1 },
       { "expression": "exp(1)", "result": 2.718281828459045 },
       {
         "data": "'purchase-order'",
@@ -1151,7 +1151,7 @@
       {
         "data": "'purchase-order'",
         "expression": "entries(address.country)",
-        "error": "TypeError"
+        "result": [["0", "USA"]]
       },
       {
         "expression": "fromEntries([[\"a\", 1], [\"b\", 2, 4], [\"a\", 3]])",
@@ -1440,7 +1440,7 @@
         ]
       },
       { "expression": "zip([1,2,3])", "result": [[1], [2], [3]] },
-      { "expression": "zip([])", "result": [] },
+      { "expression": "zip(`[]`)", "result": [] },
       { "expression": "null() == `null`", "result": true },
       { "expression": "null() == notfound", "result": true },
       {


### PR DESCRIPTION
## Description
- Allow many of our functions to accept array parameters where we previously allowed only scalars
- Change the coercion rules so that we get fewer TypeError failures

## Related Issue
https://github.com/adobe/json-formula/issues/185 
https://github.com/adobe/json-formula/issues/186

## Tasks

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.