### PR TITLE
fix problem where trailing blanks confused toNumber()

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -2549,7 +2549,7 @@ export default function functions(
             debug.push(`Failed to convert "${num}" base "${base}" to number`);
             return null;
           }
-          const parts = num.split('.');
+          const parts = num.split('.').map(p => p.trim());
 
           let decimal = 0;
           if (parts.length > 1) {

--- a/test/functions.json
+++ b/test/functions.json
@@ -1157,6 +1157,8 @@
       { "expression": "toNumber(\" 011\\n\", 8)", "result": 9},
       { "expression": "toNumber(\" -011\\n\", 8)", "result": -9},
       { "expression": "toNumber(\" +011\\n\", 8)", "result": 9},
+      { "expression": "toNumber(\" 070.070 \", 8)", "result": 56.109375},
+      { "expression": "toNumber(\" 0F0.0F0 \", 16)", "result": 240.05859375},
       {
         "expression": "'toString'(`1.0`)",
         "error": "SyntaxError"


### PR DESCRIPTION
## Description
trailing spaces confused toNumber for base 8 and base 64

## Related Issue
https://github.com/adobe/json-formula/issues/183

## Tasks
- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.