### PR TITLE
update tests to match expected order of object keys

### DIFF
--- a/test/jsonformula.spec.js
+++ b/test/jsonformula.spec.js
@@ -144,6 +144,10 @@ function executeTest(desc, tst) {
     expect(result).toBeCloseTo(tst.result, 5);
   } else {
     expect(result).toEqual(tst.result);
+    // if the results are objects, and are equal, also check that the order of keys is the same
+    if (!Array.isArray(result) && result !== null && typeof result === 'object') {
+      expect(Object.entries(result)).toEqual(Object.entries(tst.result));
+    }
   }
 }
 

--- a/test/multiselect.json
+++ b/test/multiselect.json
@@ -70,7 +70,7 @@
       },
       {
         "expression": "foo.badkey.{nokey: nokey, alsonokey: alsonokey}",
-        "result": { "alsonokey": null, "nokey": null }
+        "result": { "nokey": null, "alsonokey": null }
       },
       {
         "expression": "foo.nested.*.{a: a,b: b}",

--- a/test/syntax.json
+++ b/test/syntax.json
@@ -509,7 +509,7 @@
       {
         "comment": "Valid object expression extraction",
         "expression": "a.{foo: bar, baz: bam}",
-        "result": { "baz": null, "foo": null }
+        "result": {"foo": null , "baz": null}
       },
       {
         "comment": "Trailing comma",


### PR DESCRIPTION
## Description
Tests that compare object results should also check that the order of keys is the same.
The default jest `expect(..).toEqual(...)` allows differing order
